### PR TITLE
feat: comprehensive UI/UX overhaul

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+You are able to use the Svelte MCP server, where you have access to comprehensive Svelte 5 and SvelteKit documentation. Here's how to use the available tools effectively:
+
+## Available MCP Tools:
+
+### 1. list-sections
+
+Use this FIRST to discover all available documentation sections. Returns a structured list with titles, use_cases, and paths.
+When asked about Svelte or SvelteKit topics, ALWAYS use this tool at the start of the chat to find relevant sections.
+
+### 2. get-documentation
+
+Retrieves full documentation content for specific sections. Accepts single or multiple sections.
+After calling the list-sections tool, you MUST analyze the returned documentation sections (especially the use_cases field) and then use the get-documentation tool to fetch ALL documentation sections that are relevant for the user's task.
+
+### 3. svelte-autofixer
+
+Analyzes Svelte code and returns issues and suggestions.
+You MUST use this tool whenever writing Svelte code before sending it to the user. Keep calling it until no issues or suggestions are returned.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,22 @@ These rules MUST be followed when implementing or modifying ArbZG compliance che
 - `{@const}` can only be used inside `{#if}`, `{#each}`, `{#snippet}` — NOT inside `<div>`
 - Use `$derived` for computed values instead of `{@const}` in templates
 - Use `preventDefault` from `svelte/legacy` for form handlers
+
+You are able to use the Svelte MCP server, where you have access to comprehensive Svelte 5 and SvelteKit documentation. Here's how to use the available tools effectively:
+
+## Available MCP Tools:
+
+### 1. list-sections
+
+Use this FIRST to discover all available documentation sections. Returns a structured list with titles, use_cases, and paths.
+When asked about Svelte or SvelteKit topics, ALWAYS use this tool at the start of the chat to find relevant sections.
+
+### 2. get-documentation
+
+Retrieves full documentation content for specific sections. Accepts single or multiple sections.
+After calling the list-sections tool, you MUST analyze the returned documentation sections (especially the use_cases field) and then use the get-documentation tool to fetch ALL documentation sections that are relevant for the user's task.
+
+### 3. svelte-autofixer
+
+Analyzes Svelte code and returns issues and suggestions.
+You MUST use this tool whenever writing Svelte code before sending it to the user. Keep calling it until no issues or suggestions are returned.

--- a/apps/api/src/routes/leave.ts
+++ b/apps/api/src/routes/leave.ts
@@ -232,7 +232,7 @@ export async function leaveRoutes(app: FastifyInstance) {
           type: "LEAVE_REQUEST",
           title: "Neuer Urlaubsantrag",
           message: `${request.employee.firstName} ${request.employee.lastName} hat einen ${typeDef.name}-Antrag gestellt (${body.startDate} – ${body.endDate})`,
-          link: "/admin/vacation",
+          link: "/leave",
         });
       }
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -44,6 +44,6 @@ USER clokr
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -qO- http://localhost:3000/ || exit 1
+  CMD wget -qO- http://127.0.0.1:3000/ || exit 1
 
 CMD ["node", "apps/web/build/index.js"]

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -56,6 +56,10 @@
   --color-purple: #7c3aed;
   --color-purple-bg: #f5f3ff;
   --color-purple-border: #ddd6fe;
+  --color-orange: #c2410c;
+  --color-orange-bg: #fff7ed;
+  --color-orange-border: #fed7aa;
+  --color-danger: #ef4444;
 
   /* Typography */
   --font-sans: "Jost", system-ui, sans-serif;
@@ -147,6 +151,10 @@
   --color-purple: #a78bfa;
   --color-purple-bg: rgba(167, 139, 250, 0.1);
   --color-purple-border: rgba(167, 139, 250, 0.2);
+  --color-orange: #fb923c;
+  --color-orange-bg: rgba(194, 65, 12, 0.15);
+  --color-orange-border: rgba(194, 65, 12, 0.3);
+  --color-danger: #f87171;
 
   --font-sans: "DM Sans", system-ui, sans-serif;
 
@@ -203,6 +211,11 @@
   --gray-800: #1f2820;
   --gray-900: #1a2820;
 
+  --color-orange: #c2410c;
+  --color-orange-bg: #fff7ed;
+  --color-orange-border: #fed7aa;
+  --color-danger: #ef4444;
+
   --font-sans: "DM Sans", system-ui, sans-serif;
 
   --shadow-xs: 0 1px 3px 0 rgba(30, 60, 40, 0.06), 0 1px 2px 0 rgba(30, 60, 40, 0.04);
@@ -257,6 +270,11 @@
   --gray-700: #2c3347;
   --gray-800: #1a2038;
   --gray-900: #111827;
+
+  --color-orange: #c2410c;
+  --color-orange-bg: #fff7ed;
+  --color-orange-border: #fed7aa;
+  --color-danger: #ef4444;
 
   --font-sans: "DM Sans", system-ui, sans-serif;
 
@@ -321,13 +339,16 @@ h6 {
 }
 
 h1 {
-  font-size: 2rem;
+  font-size: 1.75rem;
+  font-weight: 700;
 }
 h2 {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
 }
 h3 {
-  font-size: 1.25rem;
+  font-size: 1rem;
+  font-weight: 600;
 }
 h4 {
   font-size: 1.0625rem;
@@ -393,20 +414,16 @@ button {
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--color-brand), var(--color-brand-dark));
+  background-color: var(--color-brand);
   color: #fff;
-  border-color: var(--color-brand-dark);
-  box-shadow:
-    0 2px 8px rgba(0, 0, 0, 0.15),
-    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  border-color: var(--color-brand);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 .btn-primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--color-brand-dark), var(--color-brand));
+  background-color: var(--color-brand-dark);
   border-color: var(--color-brand-dark);
   color: #fff;
-  box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.2),
-    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
 }
 
 .btn-secondary {
@@ -452,6 +469,14 @@ button {
   background-color: #b91c1c;
   border-color: #b91c1c;
   color: #fff;
+}
+
+.btn-icon {
+  padding: 0.5rem;
+  aspect-ratio: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* ─── Card ───────────────────────────────────────────────────────────── */
@@ -528,9 +553,9 @@ button {
 }
 
 .badge-orange {
-  background-color: #fff7ed;
-  color: #c2410c;
-  border: 1px solid #fed7aa;
+  background-color: var(--color-orange-bg);
+  color: var(--color-orange);
+  border: 1px solid var(--color-orange-border);
 }
 
 /* ─── Forms ──────────────────────────────────────────────────────────── */
@@ -602,7 +627,7 @@ select.form-input {
 
 /* ─── Page Header ────────────────────────────────────────────────────── */
 .page-header {
-  margin-bottom: 1.75rem;
+  margin-bottom: 2.25rem;
 }
 
 .page-header h1 {
@@ -847,12 +872,6 @@ select.form-input {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%237a7a95' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
 }
 
-[data-theme="nacht"] .badge-orange {
-  background-color: rgba(194, 65, 12, 0.15);
-  color: #fb923c;
-  border-color: rgba(194, 65, 12, 0.3);
-}
-
 /* ─── Filter Bar ─────────────────────────────────────────────────────── */
 .filter-bar {
   display: flex;
@@ -883,6 +902,420 @@ select.form-input {
   font-size: 0.8125rem;
   color: var(--color-text-muted);
   white-space: nowrap;
+}
+
+/* ─── Page Transitions ──────────────────────────────────────────────── */
+@keyframes page-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.page-enter {
+  animation: page-enter 0.3s var(--ease-out) both;
+}
+
+/* ─── Staggered Card Animations ─────────────────────────────────────── */
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.card-animate {
+  animation: card-enter 0.4s var(--ease-out) both;
+}
+
+.card-animate:nth-child(1) {
+  animation-delay: 0ms;
+}
+.card-animate:nth-child(2) {
+  animation-delay: 60ms;
+}
+.card-animate:nth-child(3) {
+  animation-delay: 120ms;
+}
+.card-animate:nth-child(4) {
+  animation-delay: 180ms;
+}
+.card-animate:nth-child(5) {
+  animation-delay: 240ms;
+}
+.card-animate:nth-child(6) {
+  animation-delay: 300ms;
+}
+
+/* ─── Micro-Interactions ────────────────────────────────────────────── */
+.stat-card {
+  transition:
+    background-color 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.2s var(--ease-out);
+}
+
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.card-interactive {
+  transition:
+    background-color 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.2s var(--ease-out);
+  cursor: default;
+}
+
+.card-interactive:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+/* ─── Animated Counter ──────────────────────────────────────────────── */
+@keyframes count-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.stat-value-animate {
+  animation: count-up 0.5s var(--ease-out) both;
+  animation-delay: 0.2s;
+}
+
+/* ─── Pulse animation for active clock-in ───────────────────────────── */
+@keyframes pulse-ring {
+  0% {
+    box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(22, 163, 74, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(22, 163, 74, 0);
+  }
+}
+
+.pulse-active {
+  animation: pulse-ring 2s ease infinite;
+}
+
+/* ─── Button press effect ───────────────────────────────────────────── */
+.btn-press:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+/* ─── Skeleton Variants ─────────────────────────────────────────────── */
+.skeleton-text {
+  height: 1em;
+  border-radius: 4px;
+}
+
+.skeleton-heading {
+  height: 2rem;
+  width: 60%;
+  border-radius: var(--radius-sm);
+}
+
+.skeleton-stat {
+  height: 2.5rem;
+  width: 80%;
+  border-radius: var(--radius-sm);
+}
+
+.skeleton-card {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  padding: 1.5rem 1.75rem;
+  min-height: 120px;
+}
+
+/* ─── Improved Section Spacing ──────────────────────────────────────── */
+.section-gap {
+  margin-bottom: 2.5rem;
+}
+
+.section-gap-sm {
+  margin-bottom: 1.75rem;
+}
+
+.page-header {
+  margin-bottom: 2.25rem;
+}
+
+/* ─── Enhanced Form Inputs ──────────────────────────────────────────── */
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-icon {
+  position: absolute;
+  left: 0.875rem;
+  color: var(--gray-400);
+  pointer-events: none;
+  z-index: 1;
+  transition: color 0.15s;
+}
+
+.input-wrapper:focus-within .input-icon {
+  color: var(--color-brand);
+}
+
+.form-input--icon {
+  padding-left: 2.5rem;
+}
+
+.form-input--password {
+  padding-right: 2.75rem;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.375rem;
+  border-radius: var(--radius-sm);
+  color: var(--gray-400);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    color 0.15s,
+    background-color 0.15s;
+}
+
+.password-toggle:hover {
+  color: var(--color-text);
+  background-color: var(--color-bg-subtle);
+}
+
+/* Smoother focus transition */
+.form-input {
+  transition:
+    border-color 0.2s var(--ease-out),
+    box-shadow 0.2s var(--ease-out),
+    background-color 0.25s;
+}
+
+/* Date and time input improvements */
+input[type="date"].form-input,
+input[type="time"].form-input,
+input[type="datetime-local"].form-input {
+  cursor: pointer;
+}
+
+input[type="date"].form-input::-webkit-calendar-picker-indicator,
+input[type="time"].form-input::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+}
+
+input[type="date"].form-input::-webkit-calendar-picker-indicator:hover,
+input[type="time"].form-input::-webkit-calendar-picker-indicator:hover {
+  opacity: 1;
+}
+
+/* Textarea auto-resize hint */
+textarea.form-input {
+  min-height: 80px;
+  resize: vertical;
+}
+
+/* ─── Enhanced Tables ───────────────────────────────────────────────── */
+.data-table thead tr {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: var(--color-surface);
+}
+
+.data-table th.sortable {
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.15s;
+}
+
+.data-table th.sortable:hover {
+  color: var(--color-brand);
+}
+
+.data-table th .sort-indicator {
+  display: inline-flex;
+  margin-left: 0.25rem;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+}
+
+.data-table th.sortable:hover .sort-indicator {
+  opacity: 0.7;
+}
+
+.data-table th.sorted .sort-indicator {
+  opacity: 1;
+  color: var(--color-brand);
+}
+
+/* Row action overlay on hover */
+.data-table .row-actions {
+  opacity: 0;
+  transition: opacity 0.15s;
+  display: flex;
+  gap: 0.25rem;
+  align-items: center;
+}
+
+.data-table tbody tr:hover .row-actions {
+  opacity: 1;
+}
+
+/* Compact table variant */
+.data-table--compact td {
+  padding: 0.625rem 1rem;
+}
+
+.data-table--compact th {
+  padding: 0.625rem 1rem;
+}
+
+/* ─── Accessibility ─────────────────────────────────────────────────── */
+.skip-to-content {
+  position: absolute;
+  top: -100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-brand);
+  color: #fff;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
+  z-index: 10000;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: top 0.2s;
+}
+
+.skip-to-content:focus {
+  top: 0;
+}
+
+/* Improved focus-visible styles */
+:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 2px;
+}
+
+/* Remove outline on mouse click, keep on keyboard */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* High contrast mode support */
+@media (forced-colors: active) {
+  .badge,
+  .btn,
+  .alert {
+    border: 1px solid ButtonText;
+  }
+}
+
+/* Modal / Dialog base */
+.dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 500;
+  animation: backdrop-in 0.15s ease;
+}
+
+@keyframes backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.dialog-content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--glass-bg-strong, var(--color-surface));
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: 501;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: dialog-in 0.2s var(--ease-out);
+}
+
+@keyframes dialog-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -48%);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%);
+  }
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.dialog-header h2 {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.dialog-body {
+  padding: 1.5rem;
+}
+
+.dialog-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+/* Nacht theme dialog */
+[data-theme="nacht"] .dialog-content {
+  background: var(--glass-bg-strong);
+  border-color: var(--glass-border);
 }
 
 /* ─── Reduced Motion ─────────────────────────────────────────────────── */

--- a/apps/web/src/lib/components/ui/Breadcrumb.svelte
+++ b/apps/web/src/lib/components/ui/Breadcrumb.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  interface Crumb {
+    label: string;
+    href?: string;
+  }
+
+  interface Props {
+    crumbs: Crumb[];
+  }
+
+  let { crumbs }: Props = $props();
+</script>
+
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <ol class="breadcrumb-list">
+    {#each crumbs as crumb, i}
+      <li class="breadcrumb-item">
+        {#if i > 0}
+          <svg
+            class="breadcrumb-sep"
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg
+          >
+        {/if}
+        {#if crumb.href && i < crumbs.length - 1}
+          <a href={crumb.href} class="breadcrumb-link">{crumb.label}</a>
+        {:else}
+          <span
+            class="breadcrumb-current"
+            aria-current={i === crumbs.length - 1 ? "page" : undefined}>{crumb.label}</span
+          >
+        {/if}
+      </li>
+    {/each}
+  </ol>
+</nav>
+
+<style>
+  .breadcrumb {
+    margin-bottom: 1rem;
+  }
+
+  .breadcrumb-list {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 0.8125rem;
+  }
+
+  .breadcrumb-item {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .breadcrumb-sep {
+    color: var(--color-text-muted);
+    opacity: 0.5;
+  }
+
+  .breadcrumb-link {
+    color: var(--color-text-muted);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+
+  .breadcrumb-link:hover {
+    color: var(--color-brand);
+  }
+
+  .breadcrumb-current {
+    color: var(--color-text);
+    font-weight: 500;
+  }
+</style>

--- a/apps/web/src/lib/components/ui/CommandPalette.svelte
+++ b/apps/web/src/lib/components/ui/CommandPalette.svelte
@@ -1,0 +1,620 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { authStore } from "$stores/auth";
+  import { focusTrap } from "$lib/utils/focus-trap";
+
+  interface Action {
+    id: string;
+    label: string;
+    description: string;
+    icon: string;
+    href: string;
+    group: string;
+    adminOnly?: boolean;
+  }
+
+  interface ActionGroup {
+    name: string;
+    items: Action[];
+  }
+
+  const allActions: Action[] = [
+    {
+      id: "dashboard",
+      label: "Dashboard",
+      description: "Zur Startseite",
+      icon: "home",
+      href: "/dashboard",
+      group: "Navigation",
+    },
+    {
+      id: "time-entries",
+      label: "Zeiteinträge",
+      description: "Arbeitszeiten verwalten",
+      icon: "clock",
+      href: "/time-entries",
+      group: "Navigation",
+    },
+    {
+      id: "leave",
+      label: "Abwesenheiten",
+      description: "Urlaub & Krankmeldungen",
+      icon: "calendar",
+      href: "/leave",
+      group: "Navigation",
+    },
+    {
+      id: "reports",
+      label: "Berichte",
+      description: "Auswertungen & Exporte",
+      icon: "chart",
+      href: "/reports",
+      group: "Navigation",
+    },
+    {
+      id: "admin",
+      label: "Admin",
+      description: "Verwaltung",
+      icon: "settings",
+      href: "/admin",
+      group: "Navigation",
+      adminOnly: true,
+    },
+    {
+      id: "admin-shifts",
+      label: "Schichtplan",
+      description: "Schichten verwalten",
+      icon: "calendar",
+      href: "/admin/shifts",
+      group: "Admin",
+      adminOnly: true,
+    },
+    {
+      id: "admin-vacation",
+      label: "Urlaub & Zeiten",
+      description: "Arbeitszeiten konfigurieren",
+      icon: "settings",
+      href: "/admin/vacation",
+      group: "Admin",
+      adminOnly: true,
+    },
+  ];
+
+  let open = $state(false);
+  let query = $state("");
+  let selectedIndex = $state(0);
+  let inputRef: HTMLInputElement | undefined = $state();
+
+  let isManager = $derived(["ADMIN", "MANAGER"].includes($authStore.user?.role ?? ""));
+
+  let filtered = $derived(
+    allActions
+      .filter((a) => !a.adminOnly || isManager)
+      .filter((a) => {
+        if (!query.trim()) return true;
+        const q = query.toLowerCase();
+        return a.label.toLowerCase().includes(q) || a.description.toLowerCase().includes(q);
+      }),
+  );
+
+  let grouped = $derived(
+    filtered.reduce<ActionGroup[]>((groups, action) => {
+      const existing = groups.find((g) => g.name === action.group);
+      if (existing) {
+        existing.items.push(action);
+      } else {
+        groups.push({ name: action.group, items: [action] });
+      }
+      return groups;
+    }, []),
+  );
+
+  // Build a flat index map: for each action in the grouped list, calculate its flat index
+  function getFlatIndex(groupIndex: number, itemIndex: number): number {
+    let idx = 0;
+    for (let g = 0; g < groupIndex; g++) {
+      idx += grouped[g].items.length;
+    }
+    return idx + itemIndex;
+  }
+
+  function handleGlobalKeydown(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      e.preventDefault();
+      open = !open;
+      query = "";
+      selectedIndex = 0;
+    }
+  }
+
+  function handleInputKeydown(e: KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      selectedIndex = (selectedIndex + 1) % filtered.length;
+      scrollActiveIntoView();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      selectedIndex = (selectedIndex - 1 + filtered.length) % filtered.length;
+      scrollActiveIntoView();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (filtered[selectedIndex]) {
+        select(filtered[selectedIndex]);
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    }
+  }
+
+  function scrollActiveIntoView() {
+    requestAnimationFrame(() => {
+      const active = document.querySelector(".cmd-item--active");
+      active?.scrollIntoView({ block: "nearest" });
+    });
+  }
+
+  function select(action: Action) {
+    close();
+    if (action.href) goto(action.href);
+  }
+
+  function close() {
+    open = false;
+    query = "";
+    selectedIndex = 0;
+  }
+
+  // Reset selection when query changes
+  $effect(() => {
+    // Access query to track it
+    query;
+    selectedIndex = 0;
+  });
+
+  // Focus input when opening
+  $effect(() => {
+    if (open) {
+      requestAnimationFrame(() => {
+        inputRef?.focus();
+      });
+    }
+  });
+</script>
+
+<svelte:window onkeydown={handleGlobalKeydown} />
+
+{#if open}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="cmd-backdrop" onclick={close} onkeydown={() => {}}></div>
+
+  <div class="cmd-palette" use:focusTrap role="dialog" aria-label="Schnellsuche" aria-modal="true">
+    <div class="cmd-search">
+      <svg
+        class="cmd-search-icon"
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.3-4.3" />
+      </svg>
+      <input
+        bind:this={inputRef}
+        type="text"
+        bind:value={query}
+        placeholder="Suchen oder navigieren..."
+        class="cmd-input"
+        onkeydown={handleInputKeydown}
+        aria-label="Suche"
+        autocomplete="off"
+        spellcheck="false"
+      />
+      <kbd class="cmd-kbd">ESC</kbd>
+    </div>
+
+    <div class="cmd-results">
+      {#each grouped as group, gi}
+        <div class="cmd-group-label">{group.name}</div>
+        {#each group.items as action, ii}
+          {@const flatIdx = getFlatIndex(gi, ii)}
+          <button
+            class="cmd-item"
+            class:cmd-item--active={flatIdx === selectedIndex}
+            onclick={() => select(action)}
+            onmouseenter={() => {
+              selectedIndex = flatIdx;
+            }}
+          >
+            <span class="cmd-item-icon">
+              {#if action.icon === "home"}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                  <polyline points="9 22 9 12 15 12 15 22" />
+                </svg>
+              {:else if action.icon === "clock"}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+              {:else if action.icon === "calendar"}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+                  <line x1="16" x2="16" y1="2" y2="6" />
+                  <line x1="8" x2="8" y1="2" y2="6" />
+                  <line x1="3" x2="21" y1="10" y2="10" />
+                </svg>
+              {:else if action.icon === "chart"}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M3 3v18h18" />
+                  <path d="M18 17V9" />
+                  <path d="M13 17V5" />
+                  <path d="M8 17v-3" />
+                </svg>
+              {:else if action.icon === "settings"}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+                  />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              {/if}
+            </span>
+            <div class="cmd-item-text">
+              <span class="cmd-item-label">{action.label}</span>
+              <span class="cmd-item-desc">{action.description}</span>
+            </div>
+            <svg
+              class="cmd-item-arrow"
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        {/each}
+      {/each}
+
+      {#if filtered.length === 0}
+        <p class="cmd-empty">Keine Ergebnisse für &bdquo;{query}&ldquo;</p>
+      {/if}
+    </div>
+
+    <div class="cmd-footer">
+      <span class="cmd-hint">
+        <kbd class="cmd-kbd-sm">&uarr;</kbd>
+        <kbd class="cmd-kbd-sm">&darr;</kbd>
+        Navigieren
+      </span>
+      <span class="cmd-hint">
+        <kbd class="cmd-kbd-sm">&crarr;</kbd>
+        Öffnen
+      </span>
+      <span class="cmd-hint">
+        <kbd class="cmd-kbd-sm">ESC</kbd>
+        Schließen
+      </span>
+    </div>
+  </div>
+{/if}
+
+<style>
+  /* ── Backdrop ────────────────────────────────────────────────────── */
+  .cmd-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 9000;
+    animation: cmd-fade-in 0.15s ease-out;
+  }
+
+  /* ── Palette ─────────────────────────────────────────────────────── */
+  .cmd-palette {
+    position: fixed;
+    top: 20%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90vw;
+    max-width: 560px;
+    max-height: 420px;
+    z-index: 9001;
+    display: flex;
+    flex-direction: column;
+    background: var(--glass-bg-strong, var(--color-surface));
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    box-shadow:
+      var(--shadow-lg),
+      0 0 0 1px rgba(0, 0, 0, 0.03);
+    overflow: hidden;
+    animation: cmd-scale-in 0.15s var(--ease-out);
+  }
+
+  /* ── Search ──────────────────────────────────────────────────────── */
+  .cmd-search {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.875rem 1rem;
+    border-bottom: 1px solid var(--color-border-subtle);
+    flex-shrink: 0;
+  }
+
+  .cmd-search-icon {
+    flex-shrink: 0;
+    color: var(--color-text-muted);
+  }
+
+  .cmd-input {
+    flex: 1;
+    background: none;
+    border: none;
+    outline: none;
+    font-size: 1.0625rem;
+    font-family: var(--font-sans);
+    color: var(--color-text);
+    caret-color: var(--color-brand);
+    min-width: 0;
+  }
+
+  .cmd-input::placeholder {
+    color: var(--color-text-muted);
+    opacity: 0.7;
+  }
+
+  .cmd-kbd {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.125rem 0.4rem;
+    font-size: 0.6875rem;
+    font-family: var(--font-sans);
+    font-weight: 600;
+    color: var(--color-text-muted);
+    background: var(--color-bg-subtle);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    line-height: 1.4;
+  }
+
+  /* ── Results ─────────────────────────────────────────────────────── */
+  .cmd-results {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.375rem 0;
+  }
+
+  .cmd-group-label {
+    padding: 0.5rem 1rem 0.25rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    opacity: 0.7;
+  }
+
+  .cmd-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    padding: 0.625rem 1rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    font-family: var(--font-sans);
+    color: var(--color-text);
+    transition:
+      background-color 0.08s,
+      color 0.08s;
+    position: relative;
+  }
+
+  .cmd-item:hover,
+  .cmd-item--active {
+    background-color: var(--color-brand-tint);
+    color: var(--color-brand);
+  }
+
+  .cmd-item--active .cmd-item-desc {
+    color: var(--color-brand-light);
+  }
+
+  .cmd-item--active .cmd-item-icon {
+    color: var(--color-brand);
+  }
+
+  .cmd-item--active .cmd-item-arrow {
+    opacity: 1;
+    color: var(--color-brand);
+  }
+
+  .cmd-item-icon {
+    flex-shrink: 0;
+    width: 1.5rem;
+    height: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-muted);
+    transition: color 0.08s;
+  }
+
+  .cmd-item-text {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.0625rem;
+    min-width: 0;
+  }
+
+  .cmd-item-label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.3;
+  }
+
+  .cmd-item-desc {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    line-height: 1.3;
+    transition: color 0.08s;
+  }
+
+  .cmd-item-arrow {
+    flex-shrink: 0;
+    opacity: 0;
+    color: var(--color-text-muted);
+    transition: opacity 0.1s;
+  }
+
+  .cmd-item:hover .cmd-item-arrow {
+    opacity: 0.5;
+  }
+
+  /* ── Empty state ─────────────────────────────────────────────────── */
+  .cmd-empty {
+    padding: 2rem 1rem;
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+  }
+
+  /* ── Footer ──────────────────────────────────────────────────────── */
+  .cmd-footer {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    border-top: 1px solid var(--color-border-subtle);
+    flex-shrink: 0;
+  }
+
+  .cmd-hint {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+    opacity: 0.7;
+  }
+
+  .cmd-kbd-sm {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    height: 1.125rem;
+    padding: 0 0.25rem;
+    font-size: 0.625rem;
+    font-family: var(--font-sans);
+    font-weight: 600;
+    color: var(--color-text-muted);
+    background: var(--color-bg-subtle);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    line-height: 1;
+  }
+
+  /* ── Animations ──────────────────────────────────────────────────── */
+  @keyframes cmd-fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes cmd-scale-in {
+    from {
+      opacity: 0;
+      transform: translateX(-50%) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(-50%) scale(1);
+    }
+  }
+
+  /* ── Mobile ──────────────────────────────────────────────────────── */
+  @media (max-width: 768px) {
+    .cmd-palette {
+      top: 10%;
+      width: 94vw;
+      max-height: 70vh;
+    }
+
+    .cmd-footer {
+      display: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/components/ui/EmptyState.svelte
+++ b/apps/web/src/lib/components/ui/EmptyState.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  interface Props {
+    icon?: string;
+    title: string;
+    description?: string;
+    actionLabel?: string;
+    onaction?: () => void;
+  }
+
+  let { icon = "inbox", title, description, actionLabel, onaction }: Props = $props();
+</script>
+
+<!-- Render an empty state with an SVG icon, title, optional description and CTA -->
+<div class="empty-state">
+  <div class="empty-state-icon">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="48"
+      height="48"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      {#if icon === "inbox"}
+        <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+        <path
+          d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"
+        />
+      {:else if icon === "calendar"}
+        <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+        <line x1="16" x2="16" y1="2" y2="6" />
+        <line x1="8" x2="8" y1="2" y2="6" />
+        <line x1="3" x2="21" y1="10" y2="10" />
+      {:else if icon === "clock"}
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      {:else if icon === "bar-chart"}
+        <path d="M3 3v18h18" />
+        <path d="M18 17V9" />
+        <path d="M13 17V5" />
+        <path d="M8 17v-3" />
+      {:else if icon === "users"}
+        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+      {:else if icon === "file-text"}
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="16" x2="8" y1="13" y2="13" />
+        <line x1="16" x2="8" y1="17" y2="17" />
+        <polyline points="10 9 9 9 8 9" />
+      {:else if icon === "sun"}
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2" />
+        <path d="M12 20v2" />
+        <path d="m4.93 4.93 1.41 1.41" />
+        <path d="m17.66 17.66 1.41 1.41" />
+        <path d="M2 12h2" />
+        <path d="M20 12h2" />
+        <path d="m6.34 17.66-1.41 1.41" />
+        <path d="m19.07 4.93-1.41 1.41" />
+      {:else if icon === "bell"}
+        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+        <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+      {:else if icon === "search"}
+        <circle cx="11" cy="11" r="8" />
+        <line x1="21" x2="16.65" y1="21" y2="16.65" />
+      {/if}
+    </svg>
+  </div>
+  <h3 class="empty-state-title">{title}</h3>
+  {#if description}
+    <p class="empty-state-description">{description}</p>
+  {/if}
+  {#if actionLabel && onaction}
+    <button class="btn btn-primary btn-sm empty-state-action" onclick={onaction}>
+      {actionLabel}
+    </button>
+  {/if}
+</div>
+
+<style>
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem 2rem;
+    text-align: center;
+    min-height: 200px;
+  }
+
+  .empty-state-icon {
+    color: var(--color-text-muted);
+    opacity: 0.4;
+    margin-bottom: 1.25rem;
+  }
+
+  .empty-state-title {
+    font-size: 1.0625rem;
+    font-weight: 600;
+    color: var(--color-text-heading);
+    margin-bottom: 0.5rem;
+  }
+
+  .empty-state-description {
+    font-size: 0.9375rem;
+    color: var(--color-text-muted);
+    max-width: 320px;
+    line-height: 1.5;
+    margin-bottom: 1.25rem;
+  }
+
+  .empty-state-action {
+    margin-top: 0.5rem;
+  }
+</style>

--- a/apps/web/src/lib/components/ui/Toast.svelte
+++ b/apps/web/src/lib/components/ui/Toast.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  import { toasts, type Toast } from "$stores/toast";
+  import { fly } from "svelte/transition";
+  import { flip } from "svelte/animate";
+  import { onDestroy } from "svelte";
+
+  // Subscribe to the toast store reactively
+  let items: Toast[] = $state([]);
+  const unsubscribe = toasts.subscribe((v) => (items = v));
+  onDestroy(unsubscribe);
+
+  // Only show the last 5 toasts
+  let visible = $derived(items.slice(-5));
+
+  // Map toast type to status color CSS variable prefix
+  function colorVar(type: Toast["type"]): string {
+    switch (type) {
+      case "success":
+        return "green";
+      case "error":
+        return "red";
+      case "info":
+        return "blue";
+      case "warning":
+        return "yellow";
+    }
+  }
+</script>
+
+{#if visible.length > 0}
+  <div class="toast-container" role="status" aria-live="polite">
+    {#each visible as toast (toast.id)}
+      <div
+        class="toast toast-{toast.type}"
+        animate:flip={{ duration: 250 }}
+        in:fly={{ x: 360, duration: 350, easing: (t) => 1 - Math.pow(1 - t, 3) }}
+        out:fly={{ x: 360, duration: 250, easing: (t) => t * t }}
+        style="
+          --toast-color: var(--color-{colorVar(toast.type)});
+          --toast-bg: var(--color-{colorVar(toast.type)}-bg);
+          --toast-border: var(--color-{colorVar(toast.type)}-border);
+        "
+      >
+        <span class="toast-icon">
+          {#if toast.type === "success"}
+            <!-- Checkmark circle -->
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+              <circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="1.5" />
+              <path
+                d="M6.5 10.5L8.5 12.5L13.5 7.5"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          {:else if toast.type === "error"}
+            <!-- X circle -->
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+              <circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="1.5" />
+              <path
+                d="M7 7L13 13M13 7L7 13"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+              />
+            </svg>
+          {:else if toast.type === "info"}
+            <!-- Info circle -->
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+              <circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="1.5" />
+              <path d="M10 9V14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+              <circle cx="10" cy="6.5" r="0.75" fill="currentColor" />
+            </svg>
+          {:else}
+            <!-- Warning triangle -->
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+              <path
+                d="M10 2.5L18.5 17.5H1.5L10 2.5Z"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linejoin="round"
+              />
+              <path d="M10 8V12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+              <circle cx="10" cy="14.5" r="0.75" fill="currentColor" />
+            </svg>
+          {/if}
+        </span>
+
+        <span class="toast-message">{toast.message}</span>
+
+        <button class="toast-close" onclick={() => toasts.remove(toast.id)} aria-label="Schliessen">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path
+              d="M4 4L12 12M12 4L4 12"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .toast-container {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    max-width: 420px;
+    width: calc(100vw - 3rem);
+    pointer-events: none;
+  }
+
+  .toast {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+    padding: 0.875rem 1rem 0.875rem calc(1rem + 6px);
+    border-radius: var(--radius-sm);
+    background: var(--glass-bg-strong);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid var(--toast-border);
+    box-shadow: var(--shadow-md);
+    color: var(--color-text);
+    font-size: 0.9375rem;
+    line-height: 1.45;
+    pointer-events: auto;
+    will-change: transform, opacity;
+  }
+
+  .toast-icon {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--toast-color);
+    margin-top: 1px;
+  }
+
+  .toast-message {
+    flex: 1;
+    min-width: 0;
+    word-break: break-word;
+  }
+
+  .toast-close {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    border-radius: 4px;
+    padding: 0;
+    margin: -2px -4px -2px 0;
+    transition:
+      background-color 0.15s,
+      color 0.15s;
+  }
+
+  .toast-close:hover {
+    background-color: var(--color-bg-muted);
+    color: var(--color-text);
+  }
+
+  /* Colored left accent bar */
+  .toast::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: var(--toast-color);
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  }
+
+  /* Mobile adjustments */
+  @media (max-width: 480px) {
+    .toast-container {
+      bottom: 1rem;
+      right: 1rem;
+      left: 1rem;
+      width: auto;
+      max-width: none;
+    }
+  }
+</style>

--- a/apps/web/src/lib/stores/toast.ts
+++ b/apps/web/src/lib/stores/toast.ts
@@ -1,0 +1,36 @@
+import { writable } from "svelte/store";
+
+export interface Toast {
+  id: string;
+  type: "success" | "error" | "info" | "warning";
+  message: string;
+  duration?: number;
+}
+
+function createToastStore() {
+  const { subscribe, update } = writable<Toast[]>([]);
+
+  function add(type: Toast["type"], message: string, duration = 4000) {
+    const id = crypto.randomUUID();
+    update((toasts) => [...toasts, { id, type, message, duration }]);
+    if (duration > 0) {
+      setTimeout(() => remove(id), duration);
+    }
+    return id;
+  }
+
+  function remove(id: string) {
+    update((toasts) => toasts.filter((t) => t.id !== id));
+  }
+
+  return {
+    subscribe,
+    success: (msg: string, duration?: number) => add("success", msg, duration),
+    error: (msg: string, duration?: number) => add("error", msg, duration ?? 6000),
+    info: (msg: string, duration?: number) => add("info", msg, duration),
+    warning: (msg: string, duration?: number) => add("warning", msg, duration ?? 5000),
+    remove,
+  };
+}
+
+export const toasts = createToastStore();

--- a/apps/web/src/lib/utils/chart-theme.ts
+++ b/apps/web/src/lib/utils/chart-theme.ts
@@ -1,0 +1,78 @@
+/**
+ * Returns Chart.js-compatible colors derived from the current CSS theme variables.
+ * Call this inside onMount or after DOM is available.
+ */
+export function getChartTheme() {
+  const style = getComputedStyle(document.documentElement);
+
+  const get = (prop: string) => style.getPropertyValue(prop).trim();
+
+  return {
+    brand: get("--color-brand"),
+    brandLight: get("--color-brand-light"),
+    brandTint: get("--color-brand-tint"),
+    green: get("--color-green"),
+    red: get("--color-red"),
+    yellow: get("--color-yellow"),
+    blue: get("--color-blue"),
+    text: get("--color-text"),
+    textMuted: get("--color-text-muted"),
+    border: get("--color-border-subtle"),
+    surface: get("--color-surface"),
+    gridColor: get("--color-border-subtle"),
+    fontFamily: get("--font-sans"),
+  };
+}
+
+/**
+ * Common Chart.js defaults for consistent theming.
+ */
+export function getChartDefaults() {
+  const theme = getChartTheme();
+
+  return {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        labels: {
+          color: theme.textMuted,
+          font: { family: theme.fontFamily, size: 12 },
+          usePointStyle: true,
+          pointStyle: "circle",
+          padding: 16,
+        },
+      },
+      tooltip: {
+        backgroundColor: theme.surface,
+        titleColor: theme.text,
+        bodyColor: theme.textMuted,
+        borderColor: theme.border,
+        borderWidth: 1,
+        cornerRadius: 8,
+        padding: { x: 12, y: 8 },
+        titleFont: { family: theme.fontFamily, weight: "600" as const, size: 13 },
+        bodyFont: { family: theme.fontFamily, size: 12 },
+        boxPadding: 4,
+        usePointStyle: true,
+      },
+    },
+    scales: {
+      x: {
+        ticks: { color: theme.textMuted, font: { family: theme.fontFamily, size: 11 } },
+        grid: { color: theme.gridColor, lineWidth: 0.5 },
+        border: { display: false },
+      },
+      y: {
+        ticks: { color: theme.textMuted, font: { family: theme.fontFamily, size: 11 } },
+        grid: { color: theme.gridColor, lineWidth: 0.5 },
+        border: { display: false },
+      },
+    },
+    elements: {
+      bar: { borderRadius: 6 },
+      line: { tension: 0.3, borderWidth: 2.5 },
+      point: { radius: 3, hoverRadius: 5 },
+    },
+  };
+}

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -4,6 +4,7 @@
   import { page } from "$app/stores";
   import { authStore } from "$stores/auth";
   import { api } from "$api/client";
+  import CommandPalette from "$lib/components/ui/CommandPalette.svelte";
   interface Props {
     children?: import("svelte").Snippet;
   }
@@ -106,11 +107,11 @@
 
   let navItems = $derived(
     [
-      { href: "/dashboard", icon: "🏠", label: "Dashboard", show: true },
-      { href: "/time-entries", icon: "🕐", label: "Zeiteinträge", show: true },
-      { href: "/leave", icon: "🌴", label: "Abwesenheiten", show: true },
-      { href: "/reports", icon: "📊", label: "Berichte", show: true },
-      { href: "/admin", icon: "⚙️", label: "Admin", show: isManager },
+      { href: "/dashboard", icon: "home", label: "Dashboard", show: true },
+      { href: "/time-entries", icon: "clock", label: "Zeiteinträge", show: true },
+      { href: "/leave", icon: "calendar-off", label: "Abwesenheiten", show: true },
+      { href: "/reports", icon: "bar-chart-3", label: "Berichte", show: true },
+      { href: "/admin", icon: "settings", label: "Admin", show: isManager },
     ].filter((i) => i.show),
   );
 
@@ -122,6 +123,46 @@
   }
 </script>
 
+{#snippet navSvgIcon(name: string, size?: number)}
+  {@const s = size ?? 18}
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={s}
+    height={s}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    {#if name === "home"}
+      <path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+      <polyline points="9 22 9 12 15 12 15 22" />
+    {:else if name === "clock"}
+      <circle cx="12" cy="12" r="10" />
+      <polyline points="12 6 12 12 16 14" />
+    {:else if name === "calendar-off"}
+      <path d="M4.18 4.18A2 2 0 0 0 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 1.82-1.18" />
+      <path d="M21 15.5V6a2 2 0 0 0-2-2H9.5" />
+      <path d="M16 2v4" />
+      <path d="M3 10h7" />
+      <path d="M21 10h-5.5" />
+      <line x1="2" x2="22" y1="2" y2="22" />
+    {:else if name === "bar-chart-3"}
+      <path d="M3 3v18h18" />
+      <path d="M18 17V9" />
+      <path d="M13 17V5" />
+      <path d="M8 17v-3" />
+    {:else if name === "settings"}
+      <path
+        d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
+      />
+      <circle cx="12" cy="12" r="3" />
+    {/if}
+  </svg>
+{/snippet}
+
 <svelte:window
   onclick={handleWindowClick}
   onkeydown={(e) => {
@@ -131,6 +172,7 @@
 
 {#if $authStore.accessToken}
   <div class="app-shell">
+    <a href="#main-content" class="skip-to-content">Zum Inhalt springen</a>
     <!-- Sidebar -->
     <aside class="sidebar">
       <div class="sidebar-brand">
@@ -184,6 +226,20 @@
                       <div class="notification-item-title">{n.title}</div>
                       <div class="notification-item-message">{n.message}</div>
                       <div class="notification-item-time">{formatTimeAgo(n.createdAt)}</div>
+                      {#if n.link}
+                        <svg
+                          class="notification-arrow"
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg
+                        >
+                      {/if}
                     </button>
                   {/each}
                 {/if}
@@ -205,7 +261,7 @@
             class:nav-item--active={active}
             aria-current={active ? "page" : undefined}
           >
-            <span class="nav-icon">{item.icon}</span>
+            <span class="nav-icon">{@render navSvgIcon(item.icon)}</span>
             <span class="nav-label">{item.label}</span>
           </a>
         {/each}
@@ -232,14 +288,91 @@
           onclick={handleLogout}
           aria-label="Abmelden"
         >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline
+              points="16 17 21 12 16 7"
+            /><line x1="21" y1="12" x2="9" y2="12" /></svg
+          >
           Abmelden
         </button>
         <p class="sidebar-version">v{__APP_VERSION__}</p>
       </div>
     </aside>
 
+    <!-- Mobile Header -->
+    <header class="mobile-header">
+      <div class="mobile-header-brand">
+        <img src="/clokr-icon.png" alt="Clokr" class="mobile-header-icon" />
+        <span class="mobile-header-name">Clokr</span>
+      </div>
+      <div class="notification-wrapper">
+        <button
+          class="notification-bell"
+          onclick={() => {
+            showNotifications = !showNotifications;
+          }}
+          aria-label="Benachrichtigungen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+            <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+          </svg>
+          {#if unreadCount > 0}
+            <span class="notification-badge">{unreadCount > 9 ? "9+" : unreadCount}</span>
+          {/if}
+        </button>
+
+        {#if showNotifications}
+          <div class="notification-dropdown notification-dropdown--mobile">
+            <div class="notification-header">
+              <span class="notification-header-title">Benachrichtigungen</span>
+              {#if unreadCount > 0}
+                <button class="notification-mark-all" onclick={markAllRead}>Alle gelesen</button>
+              {/if}
+            </div>
+            <div class="notification-list">
+              {#if notifications.length === 0}
+                <p class="notification-empty">Keine Benachrichtigungen</p>
+              {:else}
+                {#each notifications as n (n.id)}
+                  <button
+                    class="notification-item"
+                    class:notification-item--unread={!n.read}
+                    onclick={() => handleNotificationClick(n)}
+                  >
+                    <div class="notification-item-title">{n.title}</div>
+                    <div class="notification-item-message">{n.message}</div>
+                    <div class="notification-item-time">{formatTimeAgo(n.createdAt)}</div>
+                  </button>
+                {/each}
+              {/if}
+            </div>
+          </div>
+        {/if}
+      </div>
+    </header>
+
     <!-- Main Content -->
-    <main class="app-main">
+    <main class="app-main" id="main-content">
       {@render children?.()}
     </main>
 
@@ -256,11 +389,13 @@
           class:mobile-nav-item--active={active}
           aria-current={active ? "page" : undefined}
         >
-          <span class="mobile-nav-icon">{item.icon}</span>
+          <span class="mobile-nav-icon">{@render navSvgIcon(item.icon, 20)}</span>
           <span class="mobile-nav-label">{item.label}</span>
         </a>
       {/each}
     </nav>
+
+    <CommandPalette />
   </div>
 {/if}
 
@@ -426,9 +561,24 @@
     background: none;
     border: none;
     border-bottom: 1px solid var(--color-border-subtle);
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 2rem 0.75rem 1rem;
     cursor: pointer;
     transition: background-color 0.12s;
+    position: relative;
+  }
+
+  .notification-arrow {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    opacity: 0;
+    color: var(--color-text-muted);
+    transition: opacity 0.15s;
+  }
+
+  .notification-item:hover .notification-arrow {
+    opacity: 0.6;
   }
 
   .notification-item:hover {
@@ -505,10 +655,12 @@
   }
 
   .nav-icon {
-    font-size: 1.125rem;
     flex-shrink: 0;
     width: 1.25rem;
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: inherit;
   }
 
   .nav-label {
@@ -576,6 +728,16 @@
     width: 100%;
     justify-content: center;
     font-size: 0.8125rem;
+    gap: 0.4rem;
+    border: 1px solid var(--color-border);
+    background-color: var(--color-bg-subtle);
+    color: var(--color-text-muted);
+  }
+
+  .logout-btn:hover {
+    background-color: var(--color-red-bg);
+    border-color: var(--color-red-border);
+    color: var(--color-red);
   }
 
   /* ── Main Content ──────────────────────────────────────────────────── */
@@ -620,10 +782,26 @@
 
   .mobile-nav-item--active {
     color: var(--color-brand);
+    font-weight: 600;
+    position: relative;
+  }
+
+  .mobile-nav-item--active::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 1.5rem;
+    height: 3px;
+    border-radius: 0 0 3px 3px;
+    background-color: var(--color-brand);
   }
 
   .mobile-nav-icon {
-    font-size: 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     line-height: 1;
   }
 
@@ -631,14 +809,63 @@
     line-height: 1;
   }
 
+  /* ── Mobile Header ────────────────────────────────────────────────── */
+  .mobile-header {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3.25rem;
+    background: var(--glass-bg-strong, var(--sidebar-bg));
+    backdrop-filter: blur(var(--glass-blur, 16px));
+    -webkit-backdrop-filter: blur(var(--glass-blur, 16px));
+    border-bottom: 1px solid var(--color-border);
+    z-index: 100;
+    padding: 0 1rem;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .mobile-header-brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .mobile-header-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+  }
+
+  .mobile-header-name {
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: var(--color-brand);
+  }
+
+  .notification-dropdown--mobile {
+    position: fixed;
+    top: 3.25rem;
+    left: 0.5rem;
+    right: 0.5rem;
+    width: auto;
+    max-height: 60vh;
+  }
+
   @media (max-width: 768px) {
+    .mobile-header {
+      display: flex;
+    }
+
     .sidebar {
       display: none;
     }
 
     .app-main {
       margin-left: 0;
-      padding: 1.25rem 1rem;
+      padding: 4.5rem 1rem 5rem;
     }
 
     .mobile-nav {

--- a/apps/web/src/routes/(app)/admin/+layout.svelte
+++ b/apps/web/src/routes/(app)/admin/+layout.svelte
@@ -3,8 +3,9 @@
   import { authStore } from "$stores/auth";
   import { goto } from "$app/navigation";
   import { onMount } from "svelte";
+  import Breadcrumb from "$lib/components/ui/Breadcrumb.svelte";
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: import("svelte").Snippet;
   }
 
   let { children }: Props = $props();
@@ -19,20 +20,24 @@
   const isAdmin = $derived($authStore.user?.role === "ADMIN");
   const isManager = $derived(["ADMIN", "MANAGER"].includes($authStore.user?.role ?? ""));
 
-  const tabs = $derived([
-    { href: "/admin/employees", label: "Mitarbeiter",    show: true },
-    { href: "/admin/vacation",  label: "Urlaub & Zeiten",show: true },
-    { href: "/admin/shifts",    label: "Schichtplan",    show: isManager },
-    { href: "/admin/shutdowns", label: "Betriebsurlaub", show: true },
-    { href: "/admin/system",    label: "System",         show: true },
-    { href: "/admin/import",    label: "Import",          show: isAdmin },
-    { href: "/admin/audit",     label: "Audit Log",      show: isAdmin },
-  ].filter(t => t.show));
+  const tabs = $derived(
+    [
+      { href: "/admin/employees", label: "Mitarbeiter", show: true },
+      { href: "/admin/vacation", label: "Urlaub & Zeiten", show: true },
+      { href: "/admin/shifts", label: "Schichtplan", show: isManager },
+      { href: "/admin/shutdowns", label: "Betriebsurlaub", show: true },
+      { href: "/admin/system", label: "System", show: true },
+      { href: "/admin/import", label: "Import", show: isAdmin },
+      { href: "/admin/audit", label: "Audit Log", show: isAdmin },
+    ].filter((t) => t.show),
+  );
 
   let pathname = $derived($page.url.pathname);
 </script>
 
 <div class="admin-shell">
+  <Breadcrumb crumbs={[{ label: "Dashboard", href: "/dashboard" }, { label: "Admin" }]} />
+
   <div class="admin-header">
     <h1 class="admin-title">Administration</h1>
     <nav class="admin-tabs" aria-label="Admin-Navigation">
@@ -85,7 +90,9 @@
     text-decoration: none;
     border-bottom: 2px solid transparent;
     margin-bottom: -2px;
-    transition: color 0.12s, border-color 0.12s;
+    transition:
+      color 0.12s,
+      border-color 0.12s;
     white-space: nowrap;
   }
 

--- a/apps/web/src/routes/(app)/admin/shifts/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/shifts/+page.svelte
@@ -916,7 +916,7 @@
   }
 
   .grid-cell--empty:hover .grid-cell__plus {
-    opacity: 1;
+    opacity: 0.4;
   }
 
   /* ── Shift block ── */

--- a/apps/web/src/routes/(app)/admin/vacation/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/vacation/+page.svelte
@@ -300,7 +300,9 @@
   <div class="alert alert-error" role="alert"><span>⚠</span><span>{error}</span></div>
 {:else}
   <!-- ── Globale Vorgaben ───────────────────────────────────────────────────── -->
-  <div class="card settings-card">
+
+  <!-- Card 1: Arbeitszeit + Überstunden -->
+  <div class="section-group">
     <!-- Arbeitszeit -->
     <div class="settings-section">
       <h3 class="section-title">Wöchentliche Arbeitszeit</h3>
@@ -431,9 +433,10 @@
         </div>
       </div>
     </div>
+  </div>
 
-    <hr class="settings-divider" />
-
+  <!-- Card 2: Urlaubsanspruch -->
+  <div class="section-group">
     <!-- Urlaub -->
     <div class="settings-section">
       <h3 class="section-title">Urlaubsanspruch</h3>
@@ -480,9 +483,10 @@
         </div>
       </div>
     </div>
+  </div>
 
-    <hr class="settings-divider" />
-
+  <!-- Card 3: Compliance + Pausen -->
+  <div class="section-group">
     <!-- Compliance -->
     <div class="settings-section">
       <h3 class="section-title">Compliance</h3>
@@ -503,7 +507,7 @@
 
     <hr class="settings-divider" />
 
-    <!-- Automatische Pausen -->
+    <!-- Pausen -->
     <div class="settings-section">
       <h3 class="section-title">Pausen</h3>
       <p class="text-muted section-desc">
@@ -537,9 +541,10 @@
         </div>
       {/if}
     </div>
+  </div>
 
-    <hr class="settings-divider" />
-
+  <!-- Card 4: Benachrichtigungen -->
+  <div class="section-group">
     <!-- Benachrichtigungen -->
     <div class="settings-section">
       <h3 class="section-title">Benachrichtigungen</h3>
@@ -642,73 +647,83 @@
 
   <!-- ── Pro-Mitarbeiter ────────────────────────────────────────────────────── -->
   {#if employees.length > 0}
-    <div class="section-label">
-      <h2>Arbeitszeit & Urlaub pro Mitarbeiter</h2>
-      <p class="text-muted">Individuelle Abweichungen von der globalen Vorgabe</p>
-    </div>
+    <div class="section-group">
+      <h3>Arbeitszeit & Urlaub pro Mitarbeiter</h3>
+      <p class="text-muted" style="font-size: 0.875rem; margin-bottom: 1rem;">
+        Individuelle Abweichungen von der globalen Vorgabe
+      </p>
 
-    <div class="table-wrapper">
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th>Nr.</th>
-            <th>Mitarbeiter</th>
-            <th class="text-center">Mo</th>
-            <th class="text-center">Di</th>
-            <th class="text-center">Mi</th>
-            <th class="text-center">Do</th>
-            <th class="text-center">Fr</th>
-            <th class="text-center">Sa</th>
-            <th class="text-center">So</th>
-            <th class="text-center">Σ/Wo</th>
-            <th>Schwelle</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each employees as emp}
-            {@const s = emp.workSchedule}
+      <div class="table-wrapper">
+        <table class="data-table">
+          <thead>
             <tr>
-              <td class="text-muted font-mono">{emp.employeeNumber}</td>
-              <td class="font-medium">{emp.firstName} {emp.lastName}</td>
-              {#if s?.type === "MONTHLY_HOURS"}
-                <td class="font-mono text-center" colspan="7">
-                  <span class="badge badge-blue">{Number(s.monthlyHours).toFixed(1)} h/Monat</span>
-                </td>
-              {:else}
-                <td class="font-mono text-center">{s ? Number(s.mondayHours).toFixed(1) : "—"}</td>
-                <td class="font-mono text-center">{s ? Number(s.tuesdayHours).toFixed(1) : "—"}</td>
-                <td class="font-mono text-center"
-                  >{s ? Number(s.wednesdayHours).toFixed(1) : "—"}</td
-                >
-                <td class="font-mono text-center">{s ? Number(s.thursdayHours).toFixed(1) : "—"}</td
-                >
-                <td class="font-mono text-center">{s ? Number(s.fridayHours).toFixed(1) : "—"}</td>
-                <td class="font-mono text-center">{s ? Number(s.saturdayHours).toFixed(1) : "—"}</td
-                >
-                <td class="font-mono text-center">{s ? Number(s.sundayHours).toFixed(1) : "—"}</td>
-              {/if}
-              <td class="font-mono text-center font-medium">
-                {#if s}
-                  {#if s.type === "MONTHLY_HOURS"}
-                    {Number(s.monthlyHours).toFixed(1)}&thinsp;h/Mo
-                  {:else}
-                    {Number(s.weeklyHours).toFixed(1)}&thinsp;h
-                  {/if}
-                {:else}
-                  <span class="badge badge-gray">Global</span>
-                {/if}
-              </td>
-              <td class="font-mono">{s ? Number(s.overtimeThreshold).toFixed(0) + " h" : "—"}</td>
-              <td>
-                <button class="btn btn-ghost btn-sm" onclick={() => openEmpModal(emp)}>
-                  Bearbeiten
-                </button>
-              </td>
+              <th>Nr.</th>
+              <th>Mitarbeiter</th>
+              <th class="text-center">Mo</th>
+              <th class="text-center">Di</th>
+              <th class="text-center">Mi</th>
+              <th class="text-center">Do</th>
+              <th class="text-center">Fr</th>
+              <th class="text-center">Sa</th>
+              <th class="text-center">So</th>
+              <th class="text-center">Σ/Wo</th>
+              <th>Schwelle</th>
+              <th></th>
             </tr>
-          {/each}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {#each employees as emp}
+              {@const s = emp.workSchedule}
+              <tr>
+                <td class="text-muted font-mono">{emp.employeeNumber}</td>
+                <td class="font-medium">{emp.firstName} {emp.lastName}</td>
+                {#if s?.type === "MONTHLY_HOURS"}
+                  <td class="font-mono text-center" colspan="7">
+                    <span class="badge badge-blue">{Number(s.monthlyHours).toFixed(1)} h/Monat</span
+                    >
+                  </td>
+                {:else}
+                  <td class="font-mono text-center">{s ? Number(s.mondayHours).toFixed(1) : "—"}</td
+                  >
+                  <td class="font-mono text-center"
+                    >{s ? Number(s.tuesdayHours).toFixed(1) : "—"}</td
+                  >
+                  <td class="font-mono text-center"
+                    >{s ? Number(s.wednesdayHours).toFixed(1) : "—"}</td
+                  >
+                  <td class="font-mono text-center"
+                    >{s ? Number(s.thursdayHours).toFixed(1) : "—"}</td
+                  >
+                  <td class="font-mono text-center">{s ? Number(s.fridayHours).toFixed(1) : "—"}</td
+                  >
+                  <td class="font-mono text-center"
+                    >{s ? Number(s.saturdayHours).toFixed(1) : "—"}</td
+                  >
+                  <td class="font-mono text-center">{s ? Number(s.sundayHours).toFixed(1) : "—"}</td
+                  >
+                {/if}
+                <td class="font-mono text-center font-medium">
+                  {#if s}
+                    {#if s.type === "MONTHLY_HOURS"}
+                      {Number(s.monthlyHours).toFixed(1)}&thinsp;h/Mo
+                    {:else}
+                      {Number(s.weeklyHours).toFixed(1)}&thinsp;h
+                    {/if}
+                  {:else}
+                    <span class="badge badge-gray">Global</span>
+                  {/if}
+                </td>
+                <td class="font-mono">{s ? Number(s.overtimeThreshold).toFixed(0) + " h" : "—"}</td>
+                <td>
+                  <button class="btn btn-ghost btn-sm" onclick={() => openEmpModal(emp)}>
+                    Bearbeiten
+                  </button>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
     </div>
   {/if}
 {/if}
@@ -966,6 +981,28 @@
 {/if}
 
 <style>
+  .section-group {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: 0;
+    margin-bottom: 1.5rem;
+    overflow: hidden;
+  }
+  .section-group > h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0;
+    padding: 1.5rem 1.75rem 0.75rem;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+  .section-group > .text-muted {
+    padding: 0 1.75rem;
+  }
+  .section-group > .table-wrapper {
+    overflow-x: auto;
+  }
+
   .settings-card {
     padding: 0;
     margin-bottom: 2rem;

--- a/apps/web/src/routes/(app)/dashboard/+page.svelte
+++ b/apps/web/src/routes/(app)/dashboard/+page.svelte
@@ -536,13 +536,6 @@
         ? "text-yellow"
         : "text-green",
   );
-
-  const quickLinks = [
-    { href: "/time-entries", icon: "🕐", label: "Zeiteinträge", desc: "Alle Einträge anzeigen" },
-    { href: "/leave", icon: "🌴", label: "Urlaub", desc: "Antrag stellen" },
-    { href: "/overtime", icon: "⏱️", label: "Überstunden", desc: "Konto einsehen" },
-    { href: "/reports", icon: "📊", label: "Berichte", desc: "Auswertungen" },
-  ];
 </script>
 
 <svelte:head>
@@ -558,11 +551,30 @@
 
   <!-- Clock-in Card -->
   <div class="clock-card card card-body">
-    <div class="clock-status">
-      <span class="clock-dot" class:clock-dot--active={clockedIn}></span>
-      <span class="clock-status-text">
-        {clockedIn ? "Eingestempelt" : "Ausgestempelt"}
-      </span>
+    <div class="clock-main-row">
+      <div class="clock-status">
+        <span class="clock-dot" class:clock-dot--active={clockedIn}></span>
+        <span class="clock-status-text">
+          {clockedIn ? "Eingestempelt" : "Ausgestempelt"}
+        </span>
+      </div>
+
+      <div class="clock-time font-mono">
+        {format(currentTime, "HH:mm:ss")}
+      </div>
+
+      <button
+        onclick={handleClock}
+        disabled={clockLoading}
+        class="btn clock-btn"
+        class:clock-btn--in={!clockedIn}
+        class:clock-btn--out={clockedIn}
+      >
+        {#if clockLoading}
+          <span class="btn-spinner"></span>
+        {/if}
+        {clockedIn ? "Ausstempeln" : "Einstempeln"}
+      </button>
     </div>
 
     {#if todayShift}
@@ -578,43 +590,28 @@
       </div>
     {/if}
 
-    <div class="clock-time font-mono">
-      {format(currentTime, "HH:mm:ss")}
-    </div>
-
-    {#if clockedIn && clockStart}
-      <p class="clock-elapsed text-muted">
-        Eingestempelt seit {format(clockStart, "HH:mm")} Uhr ·
-        <span class="font-mono">{formatElapsed(clockStart, currentTime)}</span>
-      </p>
-    {/if}
-
     {#if clockedIn}
-      <div class="clock-break">
-        <label class="form-label" for="break-input">Pause (Minuten)</label>
-        <input
-          id="break-input"
-          type="number"
-          bind:value={breakMinutes}
-          min="0"
-          max="480"
-          class="form-input clock-break-input"
-        />
+      <div class="clock-details">
+        {#if clockStart}
+          <p class="clock-elapsed text-muted">
+            Eingestempelt seit {format(clockStart, "HH:mm")} Uhr ·
+            <span class="font-mono">{formatElapsed(clockStart, currentTime)}</span>
+          </p>
+        {/if}
+
+        <div class="clock-break">
+          <label class="form-label" for="break-input">Pause (Minuten)</label>
+          <input
+            id="break-input"
+            type="number"
+            bind:value={breakMinutes}
+            min="0"
+            max="480"
+            class="form-input clock-break-input"
+          />
+        </div>
       </div>
     {/if}
-
-    <button
-      onclick={handleClock}
-      disabled={clockLoading}
-      class="btn clock-btn"
-      class:clock-btn--in={!clockedIn}
-      class:clock-btn--out={clockedIn}
-    >
-      {#if clockLoading}
-        <span class="btn-spinner"></span>
-      {/if}
-      {clockedIn ? "Ausstempeln" : "Einstempeln"}
-    </button>
   </div>
 
   <!-- Stats Row -->
@@ -868,22 +865,6 @@
       </div>
     </div>
   {/if}
-
-  <!-- Quick Links -->
-  <div class="quick-links-header">
-    <h2>Schnellzugriff</h2>
-  </div>
-  <div class="quick-links">
-    {#each quickLinks as link}
-      <a href={link.href} class="quick-link card">
-        <span class="quick-link-icon">{link.icon}</span>
-        <div>
-          <p class="quick-link-label">{link.label}</p>
-          <p class="quick-link-desc text-muted">{link.desc}</p>
-        </div>
-      </a>
-    {/each}
-  </div>
 </div>
 
 <style>
@@ -893,17 +874,27 @@
 
   /* Clock Card */
   .clock-card {
-    text-align: center;
     margin-bottom: 1.5rem;
     display: flex;
     flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .clock-main-row {
+    display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: 1.5rem;
+  }
+
+  .clock-details {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
   }
 
   .shift-info {
     display: flex;
-    justify-content: center;
   }
 
   .clock-status {
@@ -913,6 +904,7 @@
     font-size: 0.9rem;
     font-weight: 500;
     color: var(--color-text-muted);
+    white-space: nowrap;
   }
 
   .clock-dot {
@@ -929,7 +921,7 @@
   }
 
   .clock-time {
-    font-size: 3.5rem;
+    font-size: 2rem;
     font-weight: 700;
     color: var(--color-text-heading);
     letter-spacing: -0.02em;
@@ -959,6 +951,7 @@
     gap: 0.5rem;
     min-width: 160px;
     justify-content: center;
+    margin-left: auto;
   }
   .clock-btn--in {
     background-color: var(--color-green);
@@ -1004,12 +997,30 @@
     margin-bottom: 1.75rem;
   }
 
+  .stats-grid .stat-card {
+    border-left: 3px solid var(--color-brand, #6d28d9);
+  }
+
+  .stats-grid .stat-value {
+    font-size: 2rem;
+  }
+
+  .stats-grid .stat-label {
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 0.8125rem;
+  }
+
   /* Charts */
   .charts-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(2, 1fr);
     gap: 1rem;
     margin-bottom: 1.75rem;
+  }
+
+  .chart-card:last-child {
+    grid-column: 1 / -1;
   }
 
   .chart-card {
@@ -1027,7 +1038,7 @@
 
   .chart-wrap {
     position: relative;
-    height: 200px;
+    height: 240px;
   }
 
   .upcoming-section {
@@ -1261,61 +1272,26 @@
     gap: 0.375rem;
   }
 
-  /* Quick Links */
-  .quick-links-header {
-    margin-bottom: 0.875rem;
-  }
-  .quick-links-header h2 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--color-text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-  }
-  .quick-links {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 1rem;
-  }
-  .quick-link {
-    display: flex;
-    align-items: center;
-    gap: 0.875rem;
-    padding: 1.125rem 1.25rem;
-    text-decoration: none;
-    color: var(--color-text);
-    transition:
-      border-color 0.15s,
-      box-shadow 0.15s;
-  }
-  .quick-link:hover {
-    border-color: var(--color-brand-light);
-    box-shadow: var(--shadow-md);
-    color: var(--color-text);
-  }
-  .quick-link-icon {
-    font-size: 1.5rem;
-    flex-shrink: 0;
-  }
-  .quick-link-label {
-    font-size: 0.9375rem;
-    font-weight: 600;
-    color: var(--color-text-heading);
-    margin-bottom: 0.125rem;
-  }
-  .quick-link-desc {
-    font-size: 0.8125rem;
-  }
-
   @media (max-width: 900px) {
-    .stats-grid,
-    .quick-links {
+    .stats-grid {
       grid-template-columns: repeat(2, 1fr);
     }
   }
+
   @media (max-width: 480px) {
+    .clock-main-row {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.75rem;
+    }
+    .clock-btn {
+      margin-left: 0;
+    }
+    .clock-status {
+      justify-content: center;
+    }
     .clock-time {
-      font-size: 2.5rem;
+      text-align: center;
     }
   }
 </style>

--- a/apps/web/src/routes/(app)/leave/+page.svelte
+++ b/apps/web/src/routes/(app)/leave/+page.svelte
@@ -124,6 +124,47 @@
   let attestSaving = $state(false);
   let attestError = $state("");
 
+  // Drag-to-select date range in calendar
+  let dragStart: string | null = $state(null);
+  let dragEnd: string | null = $state(null);
+  let isDragging = $state(false);
+
+  function handleDayMouseDown(dateStr: string, isCurrentMonth: boolean) {
+    if (!isCurrentMonth) return;
+    isDragging = true;
+    dragStart = dateStr;
+    dragEnd = dateStr;
+  }
+
+  function handleDayMouseEnter(dateStr: string) {
+    if (!isDragging || !dragStart) return;
+    dragEnd = dateStr;
+  }
+
+  function handleDayMouseUp() {
+    if (!isDragging || !dragStart || !dragEnd) {
+      isDragging = false;
+      return;
+    }
+    isDragging = false;
+    // Ensure start <= end
+    const start = dragStart < dragEnd ? dragStart : dragEnd;
+    const end = dragStart < dragEnd ? dragEnd : dragStart;
+    formStart = start;
+    formEnd = end;
+    editingRequest = null;
+    showForm = true;
+    dragStart = null;
+    dragEnd = null;
+  }
+
+  function isDayInDragRange(dateStr: string): boolean {
+    if (!isDragging || !dragStart || !dragEnd) return false;
+    const start = dragStart < dragEnd ? dragStart : dragEnd;
+    const end = dragStart < dragEnd ? dragEnd : dragStart;
+    return dateStr >= start && dateStr <= end;
+  }
+
   const SICK_CODES: TypeCode[] = ["SICK", "SICK_CHILD"];
 
   // ── Kalender ──────────────────────────────────────────────────────────────
@@ -719,6 +760,8 @@
   <title>Abwesenheiten – Clokr</title>
 </svelte:head>
 
+<svelte:window onmouseup={handleDayMouseUp} />
+
 <!-- ── Header ─────────────────────────────────────────────────────────────── -->
 <div class="page-header-row page-header">
   <div>
@@ -1066,10 +1109,16 @@
           absences.filter((e) => e.isOwn || isManager || e.status === "APPROVED").length > 0}
         <div
           class="cal-cell"
+          class:cal-cell--current={day.isCurrentMonth}
           class:cal-other={!day.isCurrentMonth && !hasEntries && !day.isWeekend}
           class:cal-today={day.isToday}
           class:cal-weekend={day.isWeekend}
           class:cal-holiday={isHoliday && day.isCurrentMonth}
+          class:cal-cell--drag-selected={isDayInDragRange(day.dateStr)}
+          role={day.isCurrentMonth ? "button" : undefined}
+          tabindex={day.isCurrentMonth ? 0 : undefined}
+          onmousedown={() => handleDayMouseDown(day.dateStr, day.isCurrentMonth)}
+          onmouseenter={() => handleDayMouseEnter(day.dateStr)}
         >
           <span class="cal-day-num">{day.dayNum}</span>
           {#if isHoliday && day.isCurrentMonth}
@@ -2083,6 +2132,7 @@
   .cal-grid {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
+    user-select: none;
   }
   .cal-header-row {
     border-bottom: 1.5px solid var(--gray-200, #e5e7eb);
@@ -2131,6 +2181,18 @@
   .cal-holiday {
     background: #ede7f6 !important;
     border-left: 3px solid #80377b;
+  }
+
+  .cal-cell--current {
+    cursor: pointer;
+  }
+  .cal-cell--current:hover {
+    background: var(--color-bg-subtle, #f3f0ff);
+  }
+  .cal-cell--drag-selected {
+    background: var(--color-brand-tint, rgba(109, 40, 217, 0.1)) !important;
+    outline: 2px solid var(--color-brand, #6d28d9);
+    outline-offset: -2px;
   }
 
   .cal-day-num {

--- a/apps/web/src/routes/(app)/overtime/+page.svelte
+++ b/apps/web/src/routes/(app)/overtime/+page.svelte
@@ -57,13 +57,15 @@
   }
 
   function statusLabel(status: OvertimeAccount["status"]): string {
-    return status === "CRITICAL" ? "Kritisch" :
-           status === "ELEVATED" ? "Erhöht" : "Normal";
+    return status === "CRITICAL" ? "Kritisch" : status === "ELEVATED" ? "Erhöht" : "Normal";
   }
 
   function statusBadge(status: OvertimeAccount["status"]): string {
-    return status === "CRITICAL" ? "badge-red" :
-           status === "ELEVATED" ? "badge-yellow" : "badge-green";
+    return status === "CRITICAL"
+      ? "badge-red"
+      : status === "ELEVATED"
+        ? "badge-yellow"
+        : "badge-green";
   }
 
   function hoursSign(hours: string): string {
@@ -96,7 +98,7 @@
   // Filters
   let filterTxType = $state("");
   let filteredTransactions = $derived(
-    account?.transactions.filter(tx => !filterTxType || tx.type === filterTxType) ?? []
+    account?.transactions.filter((tx) => !filterTxType || tx.type === filterTxType) ?? [],
   );
 </script>
 
@@ -149,8 +151,12 @@
       <div
         class="balance-bar"
         style="
-          width: {Math.min(100, Math.abs(balance) / account.threshold * 100)}%;
-          background-color: {balance >= 60 ? 'var(--color-red)' : balance >= 40 ? 'var(--color-yellow)' : 'var(--color-green)'};
+          width: {Math.min(100, (Math.abs(balance) / account.threshold) * 100)}%;
+          background-color: {balance >= 60
+          ? 'var(--color-red)'
+          : balance >= 40
+            ? 'var(--color-yellow)'
+            : 'var(--color-green)'};
         "
       ></div>
     </div>
@@ -170,17 +176,30 @@
       <span class="empty-icon">⏱️</span>
       <h3>Keine Buchungen vorhanden</h3>
       <p class="text-muted">Es sind noch keine Überstundenbuchungen vorhanden.</p>
+      <p class="text-muted empty-subtitle">
+        Überstunden werden automatisch aus der Differenz zwischen Soll- und Ist-Arbeitszeit
+        berechnet.
+      </p>
+      <a href="/time-entries" class="btn btn-outline btn-sm" style="margin-top: 1rem"
+        >Zeiteinträge ansehen</a
+      >
     </div>
   {:else}
     <div class="filter-bar">
-      <select class="form-input filter-select" bind:value={filterTxType} aria-label="Nach Buchungsart filtern">
+      <select
+        class="form-input filter-select"
+        bind:value={filterTxType}
+        aria-label="Nach Buchungsart filtern"
+      >
         <option value="">Alle Arten</option>
         <option value="ACCRUAL">Aufbau</option>
         <option value="REDUCTION">Abbau</option>
         <option value="ADJUSTMENT">Anpassung</option>
         <option value="PAYOUT">Auszahlung</option>
       </select>
-      <span class="filter-count">{filteredTransactions.length} von {account.transactions.length}</span>
+      <span class="filter-count"
+        >{filteredTransactions.length} von {account.transactions.length}</span
+      >
     </div>
 
     <div class="table-wrapper">
@@ -299,8 +318,13 @@
   }
 
   .empty-icon {
-    font-size: 2.5rem;
-    margin-bottom: 0.25rem;
+    font-size: 3.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .empty-subtitle {
+    font-size: 0.875rem;
+    max-width: 28rem;
   }
 
   .empty-state h3 {

--- a/apps/web/src/routes/(app)/reports/+page.svelte
+++ b/apps/web/src/routes/(app)/reports/+page.svelte
@@ -41,8 +41,18 @@
   let pdfDownloading = $state<string | null>(null);
 
   const months = [
-    "Januar", "Februar", "März", "April", "Mai", "Juni",
-    "Juli", "August", "September", "Oktober", "November", "Dezember",
+    "Januar",
+    "Februar",
+    "März",
+    "April",
+    "Mai",
+    "Juni",
+    "Juli",
+    "August",
+    "September",
+    "Oktober",
+    "November",
+    "Dezember",
   ];
 
   const years = Array.from({ length: 5 }, (_, i) => currentYear - i);
@@ -53,7 +63,7 @@
     monthlyReport = null;
     try {
       monthlyReport = await api.get<MonthlyReport>(
-        `/reports/monthly?month=${reportMonth}&year=${reportYear}`
+        `/reports/monthly?month=${reportMonth}&year=${reportYear}`,
       );
     } catch (e: unknown) {
       reportError = e instanceof Error ? e.message : "Fehler beim Laden des Berichts";
@@ -71,14 +81,9 @@
       const { get } = await import("svelte/store");
       const auth = get(authStore);
 
-      const res = await fetch(
-        `/api/v1/reports/datev?month=${datevMonth}&year=${datevYear}`,
-        {
-          headers: auth.accessToken
-            ? { Authorization: `Bearer ${auth.accessToken}` }
-            : {},
-        }
-      );
+      const res = await fetch(`/api/v1/reports/datev?month=${datevMonth}&year=${datevYear}`, {
+        headers: auth.accessToken ? { Authorization: `Bearer ${auth.accessToken}` } : {},
+      });
 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
@@ -105,9 +110,7 @@
     const auth = get(authStore);
 
     const res = await fetch(`/api/v1${url}`, {
-      headers: auth.accessToken
-        ? { Authorization: `Bearer ${auth.accessToken}` }
-        : {},
+      headers: auth.accessToken ? { Authorization: `Bearer ${auth.accessToken}` } : {},
     });
 
     if (!res.ok) {
@@ -180,9 +183,11 @@
 
 <div class="reports-grid">
   <!-- Monthly Report Card -->
-  <div class="card card-body report-card">
+  <div class="card card-body report-card report-card--purple">
+    <div class="report-card-icon-section report-card-icon-section--purple">
+      <span class="report-icon-lg">📊</span>
+    </div>
     <div class="report-card-header">
-      <span class="report-icon">📊</span>
       <div>
         <h2 class="report-card-title">Monatsbericht</h2>
         <p class="report-card-desc text-muted">Übersicht aller Mitarbeiter für einen Monat</p>
@@ -208,11 +213,7 @@
       </div>
     </div>
 
-    <button
-      class="btn btn-primary"
-      onclick={loadMonthlyReport}
-      disabled={reportLoading}
-    >
+    <button class="btn btn-primary" onclick={loadMonthlyReport} disabled={reportLoading}>
       {reportLoading ? "Laden…" : "Bericht anzeigen"}
     </button>
 
@@ -225,9 +226,11 @@
   </div>
 
   <!-- DATEV Export Card -->
-  <div class="card card-body report-card">
+  <div class="card card-body report-card report-card--green">
+    <div class="report-card-icon-section report-card-icon-section--green">
+      <span class="report-icon-lg">📁</span>
+    </div>
     <div class="report-card-header">
-      <span class="report-icon">📁</span>
       <div>
         <h2 class="report-card-title">DATEV Export</h2>
         <p class="report-card-desc text-muted">CSV-Datei für DATEV-Lohnabrechnung herunterladen</p>
@@ -253,11 +256,7 @@
       </div>
     </div>
 
-    <button
-      class="btn btn-secondary"
-      onclick={downloadDatev}
-      disabled={datevLoading}
-    >
+    <button class="btn btn-secondary" onclick={downloadDatev} disabled={datevLoading}>
       {#if datevLoading}
         <span class="btn-spinner-dark"></span>
         Vorbereiten…
@@ -275,9 +274,11 @@
   </div>
 
   <!-- Leave Overview PDF Card -->
-  <div class="card card-body report-card">
+  <div class="card card-body report-card report-card--blue">
+    <div class="report-card-icon-section report-card-icon-section--blue">
+      <span class="report-icon-lg">🏖</span>
+    </div>
     <div class="report-card-header">
-      <span class="report-icon">🏖</span>
       <div>
         <h2 class="report-card-title">Urlaubsübersicht PDF</h2>
         <p class="report-card-desc text-muted">Jahresübersicht aller Urlaubsansprüche als PDF</p>
@@ -295,11 +296,7 @@
       </div>
     </div>
 
-    <button
-      class="btn btn-secondary"
-      onclick={downloadLeaveOverviewPdf}
-      disabled={leaveLoading}
-    >
+    <button class="btn btn-secondary" onclick={downloadLeaveOverviewPdf} disabled={leaveLoading}>
       {#if leaveLoading}
         <span class="btn-spinner-dark"></span>
         Vorbereiten…
@@ -322,7 +319,8 @@
   <div class="report-results">
     <div class="section-header">
       <h2>
-        Monatsbericht: {months[monthlyReport.month - 1]} {monthlyReport.year}
+        Monatsbericht: {months[monthlyReport.month - 1]}
+        {monthlyReport.year}
       </h2>
     </div>
 
@@ -357,8 +355,12 @@
                   {row.workedHours - row.shouldHours >= 0 ? "+" : ""}
                   {formatHours(Math.abs(row.workedHours - row.shouldHours))}
                 </td>
-                <td class="{row.sickDaysWithAttest > 0 ? 'text-green' : 'text-muted'}">{row.sickDaysWithAttest}</td>
-                <td class="{row.sickDaysWithoutAttest > 0 ? 'text-yellow' : 'text-muted'}">{row.sickDaysWithoutAttest}</td>
+                <td class={row.sickDaysWithAttest > 0 ? "text-green" : "text-muted"}
+                  >{row.sickDaysWithAttest}</td
+                >
+                <td class={row.sickDaysWithoutAttest > 0 ? "text-yellow" : "text-muted"}
+                  >{row.sickDaysWithoutAttest}</td
+                >
                 <td>{row.vacationDays}</td>
                 <td>
                   <button
@@ -391,19 +393,53 @@
     display: flex;
     flex-direction: column;
     gap: 1.125rem;
+    border-top: 3px solid transparent;
+    overflow: hidden;
+  }
+
+  .report-card--purple {
+    border-top-color: var(--color-brand, #7c3aed);
+  }
+
+  .report-card--green {
+    border-top-color: #16a34a;
+  }
+
+  .report-card--blue {
+    border-top-color: #2563eb;
+  }
+
+  .report-card-icon-section {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3rem;
+    height: 3rem;
+    border-radius: var(--radius-md, 8px);
+    flex-shrink: 0;
+  }
+
+  .report-card-icon-section--purple {
+    background: rgba(124, 58, 237, 0.1);
+  }
+
+  .report-card-icon-section--green {
+    background: rgba(22, 163, 74, 0.1);
+  }
+
+  .report-card-icon-section--blue {
+    background: rgba(37, 99, 235, 0.1);
+  }
+
+  .report-icon-lg {
+    font-size: 1.5rem;
+    line-height: 1;
   }
 
   .report-card-header {
     display: flex;
     align-items: flex-start;
     gap: 0.875rem;
-  }
-
-  .report-icon {
-    font-size: 1.75rem;
-    flex-shrink: 0;
-    line-height: 1;
-    margin-top: 0.125rem;
   }
 
   .report-card-title {
@@ -435,7 +471,9 @@
   }
 
   @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+      transform: rotate(360deg);
+    }
   }
 
   .report-results {

--- a/apps/web/src/routes/(app)/time-entries/+page.svelte
+++ b/apps/web/src/routes/(app)/time-entries/+page.svelte
@@ -1142,10 +1142,11 @@
     color: var(--color-text-muted);
   }
   .mstat-value {
-    font-size: 1.25rem;
-    font-weight: 700;
+    font-size: 1.5rem;
+    font-weight: 800;
     font-family: var(--font-mono);
     color: var(--color-text);
+    letter-spacing: -0.02em;
   }
   .mstat-value.bal.pos {
     color: #16a34a;
@@ -1180,15 +1181,17 @@
   }
 
   .cal-day {
-    min-height: 100px;
+    min-height: 110px;
     padding: 0.5rem 0.625rem;
     border-right: 1px solid var(--gray-100, #f3f4f6);
     border-bottom: 1px solid var(--gray-100, #f3f4f6);
     display: flex;
     flex-direction: column;
-    gap: 0.15rem;
+    gap: 0.2rem;
     cursor: pointer;
-    transition: background 0.12s;
+    transition:
+      background 0.12s,
+      box-shadow 0.12s;
     position: relative;
   }
   .cal-day:nth-child(7n) {
@@ -1220,6 +1223,7 @@
   }
   .cal-day:not(.other-month):hover {
     background: color-mix(in srgb, var(--brand) 8%, transparent);
+    box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--brand) 25%, transparent);
   }
 
   .cal-day.is-today {
@@ -1329,13 +1333,13 @@
     font-size: 0.7rem;
   }
   .day-worked {
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: 0.8125rem;
+    font-weight: 700;
     font-family: var(--font-mono);
     color: var(--color-text);
   }
   .day-bal {
-    font-size: 0.7rem;
+    font-size: 0.75rem;
     font-family: var(--font-mono);
     font-weight: 600;
   }
@@ -1769,5 +1773,57 @@
   }
   .arbzg-close:hover {
     opacity: 1;
+  }
+
+  /* ── Mobile calendar improvements ──────────────────────────────── */
+  @media (max-width: 640px) {
+    /* Reduce cell height on mobile but keep them tappable */
+    .cal-day {
+      min-height: 72px;
+      padding: 0.375rem 0.375rem;
+    }
+
+    /* Hide balance detail on mobile — show only worked hours */
+    .day-bal,
+    .day-missing {
+      display: none;
+    }
+
+    /* Compact worked-hours display */
+    .day-worked {
+      font-size: 0.6875rem;
+    }
+
+    /* Smaller day numbers on mobile */
+    .day-num {
+      font-size: 0.75rem;
+    }
+
+    /* Holiday/absence labels smaller on mobile */
+    .day-holiday-name,
+    .day-abs-type {
+      font-size: 0.5rem;
+    }
+
+    /* Larger touch target for "+ Slot" button */
+    .day-detail-header .btn-sm {
+      min-height: 44px;
+      min-width: 44px;
+      padding: 0.5rem 1rem;
+      font-size: 0.9375rem;
+    }
+
+    /* Stats bar: stack items vertically on narrow screens */
+    .mstat-item {
+      padding: 0.625rem 0.75rem;
+    }
+    .mstat-value {
+      font-size: 1.25rem;
+    }
+
+    /* Legend wraps tighter */
+    .cal-legend {
+      gap: 0.5rem 0.75rem;
+    }
   }
 </style>

--- a/apps/web/src/routes/(auth)/login/+page.svelte
+++ b/apps/web/src/routes/(auth)/login/+page.svelte
@@ -9,6 +9,7 @@
   let password = $state("");
   let error = $state("");
   let loading = $state(false);
+  let showPassword = $state(false);
 
   async function handleLogin() {
     loading = true;
@@ -51,111 +52,466 @@
 </svelte:head>
 
 <div class="login-page">
-  <div class="login-card">
-    <div class="login-logo">
-      <img src="/clokr-logo.png" alt="Clokr" class="login-logo-img" />
-      <p class="login-subtitle">Bitte melden Sie sich an</p>
+  <div class="login-container">
+    <!-- Left brand panel (desktop only) -->
+    <div class="login-brand-panel">
+      <div class="login-brand-content">
+        <img src="/clokr-logo.png" alt="Clokr" class="login-brand-logo" />
+        <h1 class="login-brand-title">Zeiterfassung, die einfach funktioniert.</h1>
+        <ul class="login-brand-features">
+          <li>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg
+            >
+            Stempeluhr & NFC
+          </li>
+          <li>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg
+            >
+            Urlaubs- & Abwesenheitsverwaltung
+          </li>
+          <li>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg
+            >
+            Berichte & DATEV-Export
+          </li>
+          <li>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg
+            >
+            ArbZG-konform
+          </li>
+        </ul>
+      </div>
     </div>
 
-    <form onsubmit={preventDefault(handleLogin)} class="login-form">
-      {#if error}
-        <div class="alert alert-error" role="alert">
-          <span>⚠</span>
-          <span>{error}</span>
+    <!-- Right form panel -->
+    <div class="login-form-panel">
+      <div class="login-card">
+        <div class="login-logo">
+          <img src="/clokr-icon.png" alt="Clokr" class="login-logo-img" />
+          <span class="login-logo-text">Clokr</span>
         </div>
-      {/if}
+        <h2 class="login-heading">Willkommen zurück</h2>
+        <p class="login-subtitle">Bitte melden Sie sich an</p>
 
-      <div class="form-group">
-        <label class="form-label" for="email">E-Mail-Adresse</label>
-        <input
-          id="email"
-          type="email"
-          bind:value={email}
-          required
-          class="form-input"
-          placeholder="max@clokr.de"
-          autocomplete="email"
-        />
+        <form onsubmit={preventDefault(handleLogin)} class="login-form">
+          {#if error}
+            <div class="alert alert-error" role="alert">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                ><circle cx="12" cy="12" r="10" /><line x1="12" x2="12" y1="8" y2="12" /><line
+                  x1="12"
+                  x2="12.01"
+                  y1="16"
+                  y2="16"
+                /></svg
+              >
+              <span>{error}</span>
+            </div>
+          {/if}
+
+          <div class="form-group">
+            <label class="form-label" for="email">E-Mail-Adresse</label>
+            <div class="input-wrapper">
+              <svg
+                class="input-icon"
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                ><rect width="20" height="16" x="2" y="4" rx="2" /><path
+                  d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"
+                /></svg
+              >
+              <input
+                id="email"
+                type="email"
+                bind:value={email}
+                required
+                class="form-input form-input--icon"
+                placeholder="max@firma.de"
+                autocomplete="email"
+              />
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="password">Passwort</label>
+            <div class="input-wrapper">
+              <svg
+                class="input-icon"
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                ><rect width="18" height="11" x="3" y="11" rx="2" ry="2" /><path
+                  d="M7 11V7a5 5 0 0 1 10 0v4"
+                /></svg
+              >
+              <input
+                id="password"
+                type={showPassword ? "text" : "password"}
+                bind:value={password}
+                required
+                class="form-input form-input--icon form-input--password"
+                placeholder="••••••••"
+                autocomplete="current-password"
+              />
+              <button
+                type="button"
+                class="password-toggle"
+                onclick={() => {
+                  showPassword = !showPassword;
+                }}
+                aria-label={showPassword ? "Passwort verbergen" : "Passwort anzeigen"}
+              >
+                {#if showPassword}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    ><path
+                      d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"
+                    /><line x1="1" x2="23" y1="1" y2="23" /></svg
+                  >
+                {:else}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    ><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" /><circle
+                      cx="12"
+                      cy="12"
+                      r="3"
+                    /></svg
+                  >
+                {/if}
+              </button>
+            </div>
+          </div>
+
+          <div class="forgot-password-link">
+            <a href="/forgot-password">Passwort vergessen?</a>
+          </div>
+
+          <button type="submit" disabled={loading} class="btn btn-primary login-submit">
+            {#if loading}
+              <span class="login-spinner"></span>
+              Anmelden…
+            {:else}
+              Anmelden
+            {/if}
+          </button>
+        </form>
       </div>
-
-      <div class="form-group">
-        <label class="form-label" for="password">Passwort</label>
-        <input
-          id="password"
-          type="password"
-          bind:value={password}
-          required
-          class="form-input"
-          placeholder="••••••••"
-          autocomplete="current-password"
-        />
-      </div>
-
-      <div class="forgot-password-link">
-        <a href="/forgot-password">Passwort vergessen?</a>
-      </div>
-
-      <button type="submit" disabled={loading} class="btn btn-primary login-submit">
-        {#if loading}
-          <span class="login-spinner"></span>
-          Anmelden…
-        {:else}
-          Anmelden
-        {/if}
-      </button>
-    </form>
-
-    <p class="login-footer">Time tracking &amp; team management</p>
+    </div>
   </div>
 </div>
 
 <style>
   .login-page {
     min-height: 100vh;
-    background-color: var(--color-bg-subtle);
+    background: var(--color-bg);
+    display: flex;
+    align-items: stretch;
+    position: relative;
+    overflow: hidden;
+  }
+
+  /* Animated gradient orbs in background */
+  .login-page::before,
+  .login-page::after {
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.15;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .login-page::before {
+    width: 600px;
+    height: 600px;
+    background: var(--color-brand);
+    top: -200px;
+    right: -100px;
+    animation: float-orb 20s ease-in-out infinite;
+  }
+
+  .login-page::after {
+    width: 400px;
+    height: 400px;
+    background: var(--color-brand-light);
+    bottom: -100px;
+    left: -50px;
+    animation: float-orb 15s ease-in-out infinite reverse;
+  }
+
+  @keyframes float-orb {
+    0%,
+    100% {
+      transform: translate(0, 0) scale(1);
+    }
+    33% {
+      transform: translate(30px, -30px) scale(1.05);
+    }
+    66% {
+      transform: translate(-20px, 20px) scale(0.95);
+    }
+  }
+
+  .login-container {
+    display: flex;
+    width: 100%;
+    min-height: 100vh;
+    position: relative;
+    z-index: 1;
+  }
+
+  /* ── Left brand panel ──────────────────────────────────── */
+  .login-brand-panel {
+    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 1.5rem;
+    padding: 3rem;
+    background: linear-gradient(135deg, var(--color-brand) 0%, var(--color-brand-dark) 100%);
+    color: #fff;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .login-brand-panel::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23ffffff' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+    opacity: 0.5;
+  }
+
+  .login-brand-content {
+    position: relative;
+    max-width: 400px;
+  }
+
+  .login-brand-logo {
+    max-width: 180px;
+    height: auto;
+    margin-bottom: 2rem;
+    filter: brightness(0) invert(1) drop-shadow(0 2px 8px rgba(0, 0, 0, 0.2));
+  }
+
+  .login-brand-title {
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 2rem;
+    color: #fff;
+    text-wrap: balance;
+  }
+
+  .login-brand-features {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.875rem;
+  }
+
+  .login-brand-features li {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 1.0625rem;
+    font-weight: 400;
+    opacity: 0.9;
+  }
+
+  .login-brand-features svg {
+    flex-shrink: 0;
+    opacity: 0.8;
+  }
+
+  /* ── Right form panel ──────────────────────────────────── */
+  .login-form-panel {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    background: var(--color-bg);
   }
 
   .login-card {
-    background: var(--color-surface, #fff);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-lg);
-    padding: 2.5rem;
     width: 100%;
-    max-width: 420px;
+    max-width: 400px;
+    animation: page-enter 0.4s var(--ease-out, ease) both;
+  }
+
+  @keyframes page-enter {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 
   .login-logo {
-    text-align: center;
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
     margin-bottom: 2rem;
   }
 
   .login-logo-img {
-    max-width: 180px;
-    height: auto;
-    margin-bottom: 0.75rem;
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+  }
+
+  .login-logo-text {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-brand);
+  }
+
+  .login-heading {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--color-text-heading);
+    margin-bottom: 0.375rem;
   }
 
   .login-subtitle {
     font-size: 0.9375rem;
     color: var(--color-text-muted);
+    margin-bottom: 2rem;
   }
 
   .login-form {
     display: flex;
     flex-direction: column;
-    gap: 1.125rem;
+    gap: 1.25rem;
+  }
+
+  /* ── Input with icon ───────────────────────────────────── */
+  .input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .input-icon {
+    position: absolute;
+    left: 0.875rem;
+    color: var(--gray-400);
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .form-input--icon {
+    padding-left: 2.5rem;
+  }
+
+  .form-input--password {
+    padding-right: 2.75rem;
+  }
+
+  .password-toggle {
+    position: absolute;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.375rem;
+    border-radius: var(--radius-sm);
+    color: var(--gray-400);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition:
+      color 0.15s,
+      background-color 0.15s;
+  }
+
+  .password-toggle:hover {
+    color: var(--color-text);
+    background-color: var(--color-bg-subtle);
   }
 
   .login-submit {
     width: 100%;
-    padding: 0.7rem 1.25rem;
+    padding: 0.75rem 1.25rem;
     font-size: 1rem;
-    margin-top: 0.25rem;
+    margin-top: 0.5rem;
   }
 
   .login-spinner {
@@ -189,10 +545,27 @@
     text-decoration: underline;
   }
 
-  .login-footer {
-    text-align: center;
-    margin-top: 1.75rem;
-    font-size: 0.8125rem;
-    color: var(--color-text-muted);
+  /* ── Responsive ────────────────────────────────────────── */
+  @media (max-width: 900px) {
+    .login-brand-panel {
+      display: none;
+    }
+
+    .login-form-panel {
+      padding: 1.5rem;
+    }
+
+    .login-card {
+      max-width: 420px;
+    }
+
+    .login-logo {
+      justify-content: center;
+    }
+
+    .login-heading,
+    .login-subtitle {
+      text-align: center;
+    }
   }
 </style>

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
   import "../app.css";
   import { theme } from "$stores/theme";
+  import Toast from "$lib/components/ui/Toast.svelte";
 
   // Importing the store initializes its subscription, which applies
   // data-theme to <html> and persists the value to localStorage.
   theme.subscribe(() => {});
 
   interface Props {
-    children?: import('svelte').Snippet;
+    children?: import("svelte").Snippet;
   }
 
   let { children }: Props = $props();
 </script>
 
 {@render children?.()}
+<Toast />


### PR DESCRIPTION
## Summary
- **SVG Icons**: Replace emoji nav icons with consistent Lucide SVGs in sidebar & mobile nav
- **Toast System**: Global toast notifications (success/error/info/warning) with auto-dismiss & glass-morphism
- **Command Palette**: Cmd+K quick navigation with fuzzy search, keyboard nav, role-based filtering
- **Login Redesign**: Split layout with brand panel, animated gradient orbs, password toggle, input icons
- **Mobile Header**: Notification bell now accessible on mobile (was hidden with sidebar)
- **Accessibility**: Skip-to-content link, improved focus-visible, forced-colors support
- **Page Transitions**: Fade-in animations, staggered card entrance, skeleton loading variants
- **Micro-Interactions**: Stat card hover lift, clock-in pulse, button press effects
- **Dark Mode Fix**: Orange/danger colors use CSS variables across all 4 themes
- **Components**: EmptyState, Breadcrumb, Dialog base classes, chart-theme utility
- **Form UX**: Icon inputs, password toggle, date picker improvements
- **Table UX**: Sticky headers, sortable column styles, row hover actions
- **Spacing**: Improved visual hierarchy with larger section gaps
- **Docker**: Fix healthcheck IPv6 issue (127.0.0.1 instead of localhost)

## New files
- `src/lib/components/ui/Toast.svelte` + `src/lib/stores/toast.ts`
- `src/lib/components/ui/CommandPalette.svelte`
- `src/lib/components/ui/EmptyState.svelte`
- `src/lib/components/ui/Breadcrumb.svelte`
- `src/lib/utils/chart-theme.ts`

## Test plan
- [ ] Login page: verify split layout on desktop, single panel on mobile (<900px)
- [ ] Password toggle: eye icon shows/hides password
- [ ] Sidebar: SVG icons render correctly in all 4 themes
- [ ] Mobile (<768px): header bar with notification bell visible
- [ ] Cmd+K: opens command palette, search works, Enter navigates
- [ ] Toast: import `toasts` store, call `toasts.success('test')` from console
- [ ] Dark mode (Nacht): badges, alerts, cards render without hardcoded white
- [ ] Skip-to-content: press Tab on page load, link appears
- [ ] Docker: `docker compose up --build -d` — all containers healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)