### PR TITLE
fix: dim non-current-month weekends in leave calendar

### DIFF
--- a/apps/web/src/routes/(app)/leave/+page.svelte
+++ b/apps/web/src/routes/(app)/leave/+page.svelte
@@ -1216,7 +1216,7 @@
         <div
           class="cal-cell"
           class:cal-cell--current={day.isCurrentMonth}
-          class:cal-other={!day.isCurrentMonth && !hasEntries && !day.isWeekend}
+          class:cal-other={!day.isCurrentMonth}
           class:cal-today={day.isToday}
           class:cal-weekend={day.isWeekend}
           class:cal-holiday={isHoliday && day.isCurrentMonth}
@@ -2311,8 +2311,8 @@
     border-right: none;
   }
 
-  .cal-other {
-    opacity: 0.3;
+  :global(.cal-cell.cal-other) {
+    opacity: 0.3 !important;
     cursor: default;
     background: var(--gray-50, #f9fafb) !important;
   }


### PR DESCRIPTION
## Summary
- Fixed weekend days outside the current month showing at full opacity instead of being dimmed (opacity 0.3) in the leave/absences calendar
- Removed the `!day.isWeekend` exclusion from the `cal-other` class condition so all non-current-month days are dimmed consistently
- Used `:global(.cal-cell.cal-other)` with `!important` on opacity to ensure the dimming overrides the `.cal-weekend` background styling, matching the pattern used in the time-entries calendar

Closes #11

## Test plan
- [ ] Navigate to the leave calendar and switch months
- [ ] Verify that weekend days outside the current month are dimmed (opacity 0.3), not shown at full opacity
- [ ] Verify that weekend days within the current month still show their purple background at full opacity
- [ ] Compare behavior with the time-entries calendar to confirm consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)