### PR TITLE
feat: manager time entry corrections

### DIFF
--- a/apps/api/src/routes/time-entries.ts
+++ b/apps/api/src/routes/time-entries.ts
@@ -871,7 +871,9 @@ export async function timeEntryRoutes(app: FastifyInstance) {
       if (overlap) return reply.code(409).send({ error: overlap });
 
       // Patch-Objekt explizit aufbauen um TS-Spread-Probleme zu vermeiden
-      const patch: Record<string, unknown> = { source: "CORRECTION" };
+      // Only set source to CORRECTION when a manager edits another employee's entry
+      const isCorrectionByManager = isManager && existing.employeeId !== user.employeeId;
+      const patch: Record<string, unknown> = isCorrectionByManager ? { source: "CORRECTION" } : {};
       if (body.date) patch.date = new Date(body.date);
       if (body.startTime) patch.startTime = new Date(body.startTime);
       if ("endTime" in body) patch.endTime = body.endTime ? new Date(body.endTime as string) : null;
@@ -918,11 +920,12 @@ export async function timeEntryRoutes(app: FastifyInstance) {
 
       await app.audit({
         userId: user.sub,
-        action: "UPDATE",
+        action: isCorrectionByManager ? "MANAGER_CORRECTION" : "UPDATE",
         entity: "TimeEntry",
         entityId: id,
         oldValue: existing,
         newValue: updated,
+        request: { ip: req.ip, headers: req.headers as Record<string, string> },
       });
 
       return { entry: updated, warnings };
@@ -930,22 +933,82 @@ export async function timeEntryRoutes(app: FastifyInstance) {
   });
 
   // PATCH /api/v1/time-entries/:id/revalidate  (Admin/Manager setzt isInvalid zurück)
+  // Optionally accepts startTime, endTime, breakMinutes to correct the entry in one step
+  const revalidateSchema = z.object({
+    startTime: z.string().datetime().optional(),
+    endTime: z.string().datetime().optional().nullable(),
+    breakMinutes: z.number().int().min(0).optional(),
+    note: z.string().optional().nullable(),
+  });
+
   app.patch("/:id/revalidate", {
     schema: { tags: ["Zeiterfassung"], security: [{ bearerAuth: [] }] },
     preHandler: requireRole("ADMIN", "MANAGER"),
     handler: async (req, reply) => {
       const { id } = req.params as { id: string };
+      const body = revalidateSchema.parse(req.body ?? {});
       const user = req.user;
 
-      const existing = await app.prisma.timeEntry.findUnique({ where: { id } });
+      const existing = await app.prisma.timeEntry.findUnique({
+        where: { id },
+        include: { employee: { select: { tenantId: true } } },
+      });
       if (!existing || existing.deletedAt)
         return reply.code(404).send({ error: "Eintrag nicht gefunden" });
+
+      // Tenant isolation
+      if (existing.employee.tenantId !== user.tenantId) {
+        return reply.code(404).send({ error: "Eintrag nicht gefunden" });
+      }
+
       if (!existing.isInvalid)
         return reply.code(400).send({ error: "Eintrag ist nicht invalidiert" });
 
+      // Gesperrte Einträge dürfen nicht revalidiert werden
+      if (existing.isLocked) {
+        return reply
+          .code(403)
+          .send({ error: "Eintrag ist gesperrt und kann nicht bearbeitet werden" });
+      }
+
+      // Build update data: always revalidate, optionally correct times
+      const updateData: Record<string, unknown> = {
+        isInvalid: false,
+        invalidReason: null,
+      };
+
+      const hasCorrection =
+        body.startTime || body.endTime !== undefined || body.breakMinutes !== undefined;
+      if (hasCorrection) {
+        updateData.source = "CORRECTION";
+        if (body.startTime) updateData.startTime = new Date(body.startTime);
+        if (body.endTime !== undefined) {
+          updateData.endTime = body.endTime ? new Date(body.endTime) : null;
+        }
+        if (body.breakMinutes !== undefined) updateData.breakMinutes = body.breakMinutes;
+
+        // Validate times
+        const newStart = body.startTime ? new Date(body.startTime) : existing.startTime;
+        const newEnd =
+          body.endTime !== undefined
+            ? body.endTime
+              ? new Date(body.endTime)
+              : null
+            : existing.endTime;
+
+        if (newEnd && newEnd <= newStart) {
+          return reply.code(400).send({ error: "Endzeit muss nach der Startzeit liegen" });
+        }
+
+        // Overlap check
+        const overlap = await checkOverlap(app, existing.employeeId, newStart, newEnd, id);
+        if (overlap) return reply.code(409).send({ error: overlap });
+      }
+      if ("note" in body) updateData.note = body.note ?? null;
+
       const updated = await app.prisma.timeEntry.update({
         where: { id },
-        data: { isInvalid: false, invalidReason: null },
+        data: updateData as any,
         include: { breaks: { orderBy: { startTime: "asc" } } },
       });
 
@@ -953,11 +1016,12 @@ export async function timeEntryRoutes(app: FastifyInstance) {
 
       await app.audit({
         userId: user.sub,
-        action: "UPDATE",
+        action: hasCorrection ? "MANAGER_CORRECTION" : "REVALIDATE",
         entity: "TimeEntry",
         entityId: id,
-        oldValue: { isInvalid: true, invalidReason: existing.invalidReason },
-        newValue: { isInvalid: false, invalidReason: null },
+        oldValue: existing,
+        newValue: updated,
+        request: { ip: req.ip, headers: req.headers as Record<string, string> },
       });
 
       return updated;

--- a/apps/web/src/routes/(app)/time-entries/+page.svelte
+++ b/apps/web/src/routes/(app)/time-entries/+page.svelte
@@ -89,6 +89,13 @@
     message: string;
   }
 
+  interface Employee {
+    id: string;
+    firstName: string;
+    lastName: string;
+    employeeNumber: string;
+  }
+
   // ── State ─────────────────────────────────────────────────────────────────
   let entries: TimeEntry[] = $state([]);
   let schedule: WorkSchedule | null = $state(null);
@@ -135,16 +142,46 @@
   let formNote = $state("");
   let defaultBreakStart: string | null = $state(null);
 
-  const employeeId = $authStore.user?.employeeId;
+  // Manager: employee selector
+  let employees: Employee[] = $state([]);
+  let selectedEmployeeId = $state<string | null>(null);
+
+  const ownEmployeeId = $authStore.user?.employeeId ?? null;
+  // The active employee ID: either the selected employee (for managers) or the logged-in user
+  let employeeId = $derived(selectedEmployeeId ?? ownEmployeeId);
+  let isViewingOther = $derived(
+    selectedEmployeeId !== null && selectedEmployeeId !== ownEmployeeId,
+  );
+  let selectedEmployeeName = $derived.by(() => {
+    if (!isViewingOther) return null;
+    const emp = employees.find((e) => e.id === selectedEmployeeId);
+    return emp ? `${emp.firstName} ${emp.lastName}` : null;
+  });
 
   // ── Laden ─────────────────────────────────────────────────────────────────
-  onMount(loadAll);
+  onMount(async () => {
+    // Load employee list for managers
+    const role = $authStore.user?.role;
+    if (role === "ADMIN" || role === "MANAGER") {
+      try {
+        const rawEmployees = await api.get<Employee[]>("/employees");
+        employees = rawEmployees;
+      } catch {
+        // Ignore — employee selector won't be shown
+      }
+    }
+    await loadAll();
+  });
 
   async function loadAll() {
     loading = true;
     error = "";
     try {
       const year = calMonth.getFullYear();
+      const activeEmpId = employeeId;
+      // When manager views another employee, pass employeeId to the API
+      const empQuery =
+        activeEmpId && activeEmpId !== ownEmployeeId ? `&employeeId=${activeEmpId}` : "";
       const [
         rawEntries,
         rawSchedule,
@@ -154,21 +191,21 @@
         rawEmployee,
         rawConfig,
       ] = await Promise.all([
-        api.get<TimeEntry[]>(`/time-entries?from=${fromDate}&to=${toDate}`),
-        employeeId
-          ? api.get<WorkSchedule>(`/settings/work/${employeeId}`).catch(() => null)
+        api.get<TimeEntry[]>(`/time-entries?from=${fromDate}&to=${toDate}${empQuery}`),
+        activeEmpId
+          ? api.get<WorkSchedule>(`/settings/work/${activeEmpId}`).catch(() => null)
           : Promise.resolve(null),
         api.get<PublicHoliday[]>(`/holidays?year=${year}`).catch(() => [] as PublicHoliday[]),
-        employeeId
+        activeEmpId
           ? api
-              .get<Absence[]>(`/leave/requests?status=APPROVED&employeeId=${employeeId}`)
+              .get<Absence[]>(`/leave/requests?status=APPROVED&employeeId=${activeEmpId}`)
               .catch(() => [] as Absence[])
           : Promise.resolve([] as Absence[]),
-        employeeId
-          ? api.get<{ balanceHours: number }>(`/overtime/${employeeId}`).catch(() => null)
+        activeEmpId
+          ? api.get<{ balanceHours: number }>(`/overtime/${activeEmpId}`).catch(() => null)
           : Promise.resolve(null),
-        employeeId
-          ? api.get<{ hireDate?: string }>(`/employees/${employeeId}`).catch(() => null)
+        activeEmpId
+          ? api.get<{ hireDate?: string }>(`/employees/${activeEmpId}`).catch(() => null)
           : Promise.resolve(null),
         api
           .get<{ arbzgEnabled?: boolean; defaultBreakStart?: string | null }>("/settings/work")
@@ -196,6 +233,11 @@
     } finally {
       loading = false;
     }
+  }
+
+  async function onEmployeeChange(newId: string) {
+    selectedEmployeeId = newId === "" ? null : newId;
+    await loadAll();
   }
 
   async function gotoMonth(dir: 1 | -1) {
@@ -505,6 +547,7 @@
         });
       } else {
         result = await api.post("/time-entries", {
+          ...(isViewingOther ? { employeeId: selectedEmployeeId } : {}),
           date: formDate,
           startTime: startISO,
           endTime: endISO,
@@ -711,6 +754,28 @@
   </button>
 </div>
 
+{#if isManager && employees.length > 0}
+  <div class="employee-selector">
+    <label class="form-label" for="emp-select">Mitarbeiter</label>
+    <select
+      id="emp-select"
+      class="form-input"
+      value={selectedEmployeeId ?? ""}
+      onchange={(e) => onEmployeeChange(e.currentTarget.value)}
+    >
+      <option value="">Meine Einträge</option>
+      {#each employees as emp (emp.id)}
+        {#if emp.id !== ownEmployeeId}
+          <option value={emp.id}>{emp.lastName}, {emp.firstName} ({emp.employeeNumber})</option>
+        {/if}
+      {/each}
+    </select>
+    {#if isViewingOther}
+      <span class="viewing-other-hint">Einträge von {selectedEmployeeName}</span>
+    {/if}
+  </div>
+{/if}
+
 <!-- ── View Tabs ──────────────────────────────────────────────────────── -->
 <div class="view-tabs">
   <button
@@ -897,7 +962,7 @@
         {#each allEntries as slot (slot.id)}
           {@const slotDate = (slot.date ?? slot.startTime).split("T")[0]}
           {@const slotArbzg = arbzgDayMap.get(slotDate)}
-          <tr>
+          <tr class:row-invalid={slot.isInvalid}>
             <td class="font-mono"
               >{new Date(slot.startTime).toLocaleDateString("de-DE", {
                 day: "2-digit",
@@ -922,9 +987,26 @@
             <td class="font-mono font-medium">{slotNet(slot)}</td>
             <td><span class="badge {sourceBadge(slot.source)}">{sourceLabel(slot.source)}</span></td
             >
-            <td class="note-cell text-muted">{slot.note ?? "---"}</td>
+            <td class="note-cell text-muted">
+              {#if slot.isInvalid && slot.invalidReason}
+                <span class="invalid-reason">{slot.invalidReason}</span>
+              {:else}
+                {slot.note ?? "---"}
+              {/if}
+            </td>
             <td class="action-cell">
-              {#if deleteConfirmId === slot.id}
+              {#if slot.isInvalid && isManager}
+                <span class="row-actions row-actions--visible">
+                  <button
+                    class="btn btn-sm btn-warning"
+                    onclick={() => revalidateEntry(slot.id)}
+                    title="Eintrag revalidieren und freigeben">Freigeben</button
+                  >
+                  <button class="btn-icon" onclick={() => openEdit(slot)} title="Korrigieren"
+                    >✏️</button
+                  >
+                </span>
+              {:else if deleteConfirmId === slot.id}
                 <span class="del-confirm">
                   <span class="text-muted" style="font-size:0.8rem;">Löschen?</span>
                   <button class="btn btn-sm btn-danger" onclick={() => deleteEntry(slot.id)}
@@ -964,7 +1046,15 @@
   <div class="modal-backdrop" onclick={self(closeModal)} role="presentation">
     <div class="modal-card card" role="dialog" aria-modal="true" tabindex="-1">
       <div class="modal-header">
-        <h2>{editEntry ? "Eintrag bearbeiten" : "Neuen Eintrag hinzufügen"}</h2>
+        <h2>
+          {editEntry
+            ? isViewingOther
+              ? `Eintrag korrigieren (${selectedEmployeeName})`
+              : "Eintrag bearbeiten"
+            : isViewingOther
+              ? `Neuer Eintrag für ${selectedEmployeeName}`
+              : "Neuen Eintrag hinzufügen"}
+        </h2>
         <button class="btn-icon modal-close" onclick={closeModal} aria-label="Schließen">
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -1085,6 +1175,46 @@
 
 <style>
   /* page-header-compact → global in app.css */
+
+  /* ── Employee Selector (Manager) ────────────────────────────────── */
+  .employee-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+    padding: 0.75rem 1rem;
+    background: var(--blue-50, #eff6ff);
+    border: 1px solid var(--blue-200, #bfdbfe);
+    border-radius: 8px;
+  }
+  .employee-selector .form-label {
+    margin: 0;
+    white-space: nowrap;
+    font-weight: 500;
+  }
+  .employee-selector .form-input {
+    max-width: 320px;
+  }
+  .viewing-other-hint {
+    font-size: 0.85rem;
+    color: var(--blue-700, #1d4ed8);
+    font-weight: 500;
+  }
+
+  /* ── Warning button ────────────────────────────────────────────── */
+  .btn-warning {
+    background: #f59e0b;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 0.25rem 0.625rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+  .btn-warning:hover {
+    background: #d97706;
+  }
 
   /* ── Kalender ─────────────────────────────────────────────────────── */
   .cal-section {


### PR DESCRIPTION
## Summary
- **API**: Managers can now properly correct other employees' time entries via `PUT /time-entries/:id` (sets `source: CORRECTION` and audit action `MANAGER_CORRECTION` only for cross-employee edits)
- **API**: Enhanced `PATCH /time-entries/:id/revalidate` to accept optional `startTime`, `endTime`, `breakMinutes`, `note` fields — managers can revalidate AND correct invalid entries in one step. Added tenant isolation, `isLocked` guard, time validation, and overlap checks.
- **Frontend**: Added employee selector dropdown for managers/admins to view and manage other employees' time entries. Invalid entries now display with visual styling, show the `invalidReason`, and offer a "Freigeben" (revalidate) button. Modal title adapts when correcting another employee's entry.

Closes #9

## Test plan
- [ ] As a manager, select another employee from the dropdown and verify their time entries load
- [ ] Edit an existing entry for another employee — verify `source` is set to `CORRECTION` and audit log shows `MANAGER_CORRECTION`
- [ ] Edit your own entry — verify `source` is NOT changed to `CORRECTION`
- [ ] Create a new entry for another employee via the modal — verify it appears under their entries
- [ ] Find an invalid entry (e.g., auto-invalidated from missing clock-out) and click "Freigeben" — verify it becomes valid
- [ ] On an invalid entry, click edit, change times, save — verify the entry is revalidated AND corrected
- [ ] Verify locked entries cannot be revalidated (403 response)
- [ ] Verify tenant isolation: manager cannot revalidate entries from another tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)