### PR TITLE
fix: update npm in base image for minimatch/tar CVEs

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -27,6 +27,8 @@ RUN pnpm --filter @clokr/api build
 # ── Stage 3: Production runtime ────────────────────────────────────────────
 FROM node:24-alpine AS runtime
 RUN apk update && apk upgrade --no-cache && apk add --no-cache su-exec
+# Update npm's bundled dependencies to fix CVEs in minimatch/tar
+RUN npm install -g npm@latest 2>/dev/null || true
 RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 WORKDIR /app
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -25,6 +25,8 @@ RUN pnpm --filter @clokr/web build
 # ── Stage 3: Production runtime ────────────────────────────────────────────
 FROM node:24-alpine AS runtime
 RUN apk update && apk upgrade --no-cache
+# Update npm's bundled dependencies to fix CVEs in minimatch/tar
+RUN npm install -g npm@latest 2>/dev/null || true
 WORKDIR /app
 
 # Copy full workspace (adapter-node needs external deps like date-fns)


### PR DESCRIPTION
Fixes remaining Trivy HIGH findings from npm bundled deps in node:24-alpine.