### PR TITLE
fix: admin area mobile/tablet responsiveness

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -713,6 +713,7 @@ select.form-input {
 /* ─── Data Table ─────────────────────────────────────────────────────── */
 .table-wrapper {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   border-radius: var(--radius-md);
   border: 1px solid var(--glass-border);
   box-shadow: var(--glass-shadow);

--- a/apps/web/src/routes/(app)/admin/+layout.svelte
+++ b/apps/web/src/routes/(app)/admin/+layout.svelte
@@ -81,6 +81,14 @@
     display: flex;
     gap: 0;
     border-bottom: 2px solid var(--color-border);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+  }
+
+  .admin-tabs::-webkit-scrollbar {
+    display: none; /* Chrome/Safari */
   }
 
   .admin-tab {
@@ -95,6 +103,14 @@
       color 0.12s,
       border-color 0.12s;
     white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  @media (max-width: 640px) {
+    .admin-tab {
+      padding: 0.5rem 0.875rem;
+      font-size: 0.8125rem;
+    }
   }
 
   .admin-tab:hover:not(.admin-tab--active) {
@@ -109,5 +125,15 @@
 
   .admin-content {
     padding-top: 0.5rem;
+  }
+
+  @media (max-width: 640px) {
+    .admin-title {
+      font-size: 1.375rem;
+    }
+
+    .admin-header {
+      margin-bottom: 1.25rem;
+    }
   }
 </style>

--- a/apps/web/src/routes/(app)/admin/audit/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/audit/+page.svelte
@@ -228,6 +228,12 @@
     padding: 1rem 1.25rem;
   }
 
+  @media (max-width: 640px) {
+    .detail-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
   .detail-label {
     font-size: 0.75rem;
     font-weight: 600;

--- a/apps/web/src/routes/(app)/admin/employees/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/employees/+page.svelte
@@ -326,7 +326,7 @@
       <span class="filter-count">{filteredEmployees.length} von {employees.length}</span>
     </div>
 
-    <div class="card">
+    <div class="card table-responsive">
       <table class="table">
         <thead>
           <tr>
@@ -705,6 +705,11 @@
     overflow: hidden;
   }
 
+  .table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
   .table {
     width: 100%;
     border-collapse: collapse;
@@ -870,6 +875,12 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 1rem;
+  }
+
+  @media (max-width: 480px) {
+    .form-grid {
+      grid-template-columns: 1fr;
+    }
   }
 
   .form-group--full {

--- a/apps/web/src/routes/(app)/admin/monatsabschluss/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/monatsabschluss/+page.svelte
@@ -620,6 +620,7 @@
   /* Table */
   .table-wrapper {
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .table {
@@ -842,5 +843,24 @@
   .summary-total {
     background: var(--gray-100, #f3f4f6);
     color: var(--gray-600, #4b5563);
+  }
+
+  @media (max-width: 640px) {
+    .control-row {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .control-group {
+      min-width: 0;
+    }
+
+    .summary-bar {
+      flex-wrap: wrap;
+    }
+
+    .reason-cell {
+      max-width: none;
+    }
   }
 </style>

--- a/apps/web/src/routes/(app)/admin/shifts/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/shifts/+page.svelte
@@ -826,6 +826,7 @@
   /* ── Grid ── */
   .grid-wrapper {
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-md);
   }

--- a/apps/web/src/routes/(app)/admin/shutdowns/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/shutdowns/+page.svelte
@@ -417,33 +417,35 @@
         {#if currentShutdown.exceptions.length === 0}
           <p class="text-muted" style="margin-bottom: 1.5rem;">Noch keine Ausnahmen angelegt.</p>
         {:else}
-          <table class="data-table" style="margin-bottom: 1.5rem;">
-            <thead>
-              <tr>
-                <th>Mitarbeiter</th>
-                <th>Nr.</th>
-                <th>Grund</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {#each currentShutdown.exceptions as ex (ex.id)}
+          <div class="table-responsive">
+            <table class="data-table" style="margin-bottom: 1.5rem;">
+              <thead>
                 <tr>
-                  <td>{ex.employee.firstName} {ex.employee.lastName}</td>
-                  <td class="text-muted">{ex.employee.employeeNumber}</td>
-                  <td class="text-muted">{ex.reason ?? "–"}</td>
-                  <td>
-                    <button
-                      class="btn btn-ghost btn-sm btn-danger"
-                      onclick={() => removeException(currentShutdown!.id, ex.employeeId)}
-                    >
-                      Entfernen
-                    </button>
-                  </td>
+                  <th>Mitarbeiter</th>
+                  <th>Nr.</th>
+                  <th>Grund</th>
+                  <th></th>
                 </tr>
-              {/each}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {#each currentShutdown.exceptions as ex (ex.id)}
+                  <tr>
+                    <td>{ex.employee.firstName} {ex.employee.lastName}</td>
+                    <td class="text-muted">{ex.employee.employeeNumber}</td>
+                    <td class="text-muted">{ex.reason ?? "–"}</td>
+                    <td>
+                      <button
+                        class="btn btn-ghost btn-sm btn-danger"
+                        onclick={() => removeException(currentShutdown!.id, ex.employeeId)}
+                      >
+                        Entfernen
+                      </button>
+                    </td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          </div>
         {/if}
 
         <!-- Mitarbeiter hinzufügen -->
@@ -793,5 +795,16 @@
 
   .text-muted {
     color: var(--color-text-muted);
+  }
+
+  .table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  @media (max-width: 640px) {
+    .form-row {
+      flex-direction: column;
+    }
   }
 </style>

--- a/apps/web/src/routes/(app)/admin/system/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/system/+page.svelte
@@ -1056,4 +1056,42 @@
   .row-revoked {
     opacity: 0.5;
   }
+
+  .table-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+
+  .section-label {
+    margin-bottom: 1rem;
+  }
+
+  .settings-card {
+    margin-bottom: 2rem;
+  }
+
+  @media (max-width: 640px) {
+    .smtp-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .form-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .inline-fields {
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .sys-section {
+      padding: 1.25rem 1rem;
+    }
+  }
 </style>

--- a/apps/web/src/routes/(app)/admin/vacation/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/vacation/+page.svelte
@@ -1001,6 +1001,7 @@
   }
   .section-group > .table-wrapper {
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   .settings-card {


### PR DESCRIPTION
## Summary
- **Admin tab navigation**: Added horizontal scroll with hidden scrollbar so all 8 tabs are accessible on mobile without causing body overflow. Reduced padding/font-size on small screens.
- **All admin tables**: Ensured every table is wrapped in a scrollable container (`table-responsive` / `table-wrapper` / `grid-wrapper`) with `-webkit-overflow-scrolling: touch` for smooth iOS scrolling.
- **System page forms**: SMTP grid and Phorest form-grid collapse to single-column layout on mobile. Inline fields (Region & Timezone) stack vertically. Section padding reduced on small screens.
- **Monatsabschluss**: Control row stacks vertically on mobile, summary bar wraps.
- **Employees**: Form modals collapse to single-column grid on very small screens.
- **Shutdowns**: Exception table wrapped in scrollable container, form rows stack on mobile.
- **Audit log**: Detail grid (before/after JSON) collapses to single column on mobile.

Closes #28 Closes #32

## Test plan
- [ ] Open admin area on 375px viewport — no horizontal overflow on body
- [ ] Admin tabs scroll horizontally on mobile, scrollbar is hidden
- [ ] Employee table scrolls horizontally if needed
- [ ] Monatsabschluss controls stack vertically on mobile
- [ ] System page SMTP/Phorest forms are single-column on mobile
- [ ] Audit log detail JSON panels stack vertically on mobile
- [ ] Shifts grid scrolls horizontally
- [ ] Shutdowns exception table scrolls in modal
- [ ] Open admin area on 768px tablet — no horizontal overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)