### PR TITLE
feat: BSI password policy + max negative hours

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -3,6 +3,7 @@ import bcrypt from "bcryptjs";
 import crypto, { createHash } from "crypto";
 import { z } from "zod";
 import { Role } from "@clokr/db";
+import { validatePassword, loadPasswordPolicy } from "../utils/password-policy";
 
 /** SHA-256 hash for tokens stored in DB (refresh tokens, reset tokens). */
 function hashToken(token: string): string {
@@ -326,6 +327,19 @@ export async function authRoutes(app: FastifyInstance) {
           .send({ error: "Der Link ist abgelaufen. Bitte fordern Sie einen neuen an." });
       }
 
+      // Load tenant password policy for the user
+      const resetUser = await app.prisma.user.findUnique({
+        where: { id: otpToken.userId },
+        include: { employee: true },
+      });
+      if (resetUser?.employee?.tenantId) {
+        const policy = await loadPasswordPolicy(app, resetUser.employee.tenantId);
+        const check = validatePassword(password, policy);
+        if (!check.valid) {
+          return reply.code(400).send({ error: check.errors.join(". ") });
+        }
+      }
+
       const passwordHash = await bcrypt.hash(password, 12);
 
       // Update password
@@ -355,6 +369,25 @@ export async function authRoutes(app: FastifyInstance) {
       });
 
       return { success: true };
+    },
+  });
+
+  // GET /api/v1/auth/password-policy — public, returns policy for the default tenant
+  // Used by invitation/reset pages to show password requirements
+  app.get("/password-policy", {
+    schema: { tags: ["Auth"] },
+    handler: async () => {
+      const tenant = await app.prisma.tenant.findFirst({
+        include: { config: true },
+      });
+      const cfg = tenant?.config;
+      return {
+        passwordMinLength: cfg?.passwordMinLength ?? 12,
+        passwordRequireUpper: cfg?.passwordRequireUpper ?? true,
+        passwordRequireLower: cfg?.passwordRequireLower ?? true,
+        passwordRequireDigit: cfg?.passwordRequireDigit ?? true,
+        passwordRequireSpecial: cfg?.passwordRequireSpecial ?? true,
+      };
     },
   });
 }

--- a/apps/api/src/routes/employees.ts
+++ b/apps/api/src/routes/employees.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import bcrypt from "bcryptjs";
 import crypto, { createHash } from "crypto";
 import { requireAuth, requireRole } from "../middleware/auth";
+import { validatePassword, loadPasswordPolicy } from "../utils/password-policy";
 
 /** SHA-256 hash for tokens stored in DB. */
 function hashToken(token: string): string {
@@ -116,6 +117,13 @@ export async function employeeRoutes(app: FastifyInstance) {
       const body = createEmployeeSchema.parse(req.body);
 
       const directPassword = !!body.password;
+      if (directPassword) {
+        const policy = await loadPasswordPolicy(app, req.user.tenantId);
+        const check = validatePassword(body.password!, policy);
+        if (!check.valid) {
+          return reply.code(400).send({ error: check.errors.join(". ") });
+        }
+      }
       const passwordHash = directPassword
         ? await bcrypt.hash(body.password!, 12)
         : await bcrypt.hash(crypto.randomBytes(32).toString("hex"), 12);

--- a/apps/api/src/routes/invitations.ts
+++ b/apps/api/src/routes/invitations.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from "fastify";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
 import { createHash } from "crypto";
+import { validatePassword, loadPasswordPolicy } from "../utils/password-policy";
 
 /** SHA-256 hash for tokens stored in DB. */
 function hashToken(token: string): string {
@@ -40,6 +41,13 @@ export async function invitationRoutes(app: FastifyInstance) {
           .send({
             error: "Dieser Link ist abgelaufen. Bitte wenden Sie sich an den Administrator.",
           });
+      }
+
+      // Validate password against tenant policy
+      const policy = await loadPasswordPolicy(app, invitation.employee.tenantId);
+      const check = validatePassword(password, policy);
+      if (!check.valid) {
+        return reply.code(400).send({ error: check.errors.join(". ") });
       }
 
       const passwordHash = await bcrypt.hash(password, 12);

--- a/apps/api/src/routes/overtime.ts
+++ b/apps/api/src/routes/overtime.ts
@@ -44,18 +44,33 @@ export async function overtimeRoutes(app: FastifyInstance) {
 
       if (!account) return reply.code(404).send({ error: "Konto nicht gefunden" });
 
-      const schedule = await app.prisma.workSchedule.findFirst({
-        where: { employeeId, validFrom: { lte: new Date() } },
-        orderBy: { validFrom: "desc" },
-      });
+      const [schedule, employee] = await Promise.all([
+        app.prisma.workSchedule.findFirst({
+          where: { employeeId, validFrom: { lte: new Date() } },
+          orderBy: { validFrom: "desc" },
+        }),
+        app.prisma.employee.findUnique({
+          where: { id: employeeId },
+          include: { tenant: { include: { config: true } } },
+        }),
+      ]);
       const threshold = Number(schedule?.overtimeThreshold ?? 60);
       const balance = Number(account.balanceHours);
+      const balanceMinutes = Math.round(balance * 60);
+
+      // Max negative hours: per-employee override > tenant default > null (unlimited)
+      const maxNegMinutes =
+        schedule?.maxNegativeBalanceMinutes ??
+        employee?.tenant?.config?.maxNegativeBalanceMinutes ??
+        null;
 
       return {
         ...account,
         status:
           balance >= threshold ? "CRITICAL" : balance >= threshold * 0.67 ? "ELEVATED" : "NORMAL",
         threshold,
+        maxNegativeBalanceMinutes: maxNegMinutes,
+        isNegativeLimitExceeded: maxNegMinutes != null && balanceMinutes < -maxNegMinutes,
       };
     },
   });

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -60,6 +60,7 @@ const employeeScheduleSchema = z
     sundayHours: z.number().min(0).max(24).default(0),
     overtimeThreshold: z.number().min(0).max(500).default(60),
     allowOvertimePayout: z.boolean().default(false),
+    maxNegativeBalanceMinutes: z.number().int().min(0).nullable().optional(),
     validFrom: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/)
@@ -483,7 +484,15 @@ export async function settingsRoutes(app: FastifyInstance) {
     handler: async (req) => {
       const tenantId = await getTenantId(app, req.user.sub);
       const cfg = await app.prisma.tenantConfig.findUnique({ where: { tenantId } });
-      return { twoFaEnabled: cfg?.twoFaEnabled ?? false };
+      return {
+        twoFaEnabled: cfg?.twoFaEnabled ?? false,
+        passwordMinLength: cfg?.passwordMinLength ?? 12,
+        passwordRequireUpper: cfg?.passwordRequireUpper ?? true,
+        passwordRequireLower: cfg?.passwordRequireLower ?? true,
+        passwordRequireDigit: cfg?.passwordRequireDigit ?? true,
+        passwordRequireSpecial: cfg?.passwordRequireSpecial ?? true,
+        maxNegativeBalanceMinutes: cfg?.maxNegativeBalanceMinutes ?? null,
+      };
     },
   });
 
@@ -492,24 +501,44 @@ export async function settingsRoutes(app: FastifyInstance) {
     schema: { tags: ["Einstellungen"], security: [{ bearerAuth: [] }] },
     preHandler: requireRole("ADMIN"),
     handler: async (req) => {
-      const { twoFaEnabled } = z.object({ twoFaEnabled: z.boolean() }).parse(req.body);
+      const body = z.object({
+        twoFaEnabled: z.boolean().optional(),
+        passwordMinLength: z.number().int().min(8).max(128).optional(),
+        passwordRequireUpper: z.boolean().optional(),
+        passwordRequireLower: z.boolean().optional(),
+        passwordRequireDigit: z.boolean().optional(),
+        passwordRequireSpecial: z.boolean().optional(),
+        maxNegativeBalanceMinutes: z.number().int().min(0).nullable().optional(),
+      }).parse(req.body);
       const tenantId = await getTenantId(app, req.user.sub);
       const oldConfig = await app.prisma.tenantConfig.findUnique({ where: { tenantId } });
-      await app.prisma.tenantConfig.upsert({
+      const config = await app.prisma.tenantConfig.upsert({
         where: { tenantId },
-        update: { twoFaEnabled },
-        create: { tenantId, twoFaEnabled },
+        update: body,
+        create: { tenantId, ...body },
       });
       await app.audit({
         userId: req.user.sub,
         action: "UPDATE",
         entity: "TenantConfig",
         entityId: tenantId,
-        oldValue: { twoFaEnabled: oldConfig?.twoFaEnabled ?? false },
-        newValue: { twoFaEnabled },
+        oldValue: {
+          twoFaEnabled: oldConfig?.twoFaEnabled ?? false,
+          passwordMinLength: oldConfig?.passwordMinLength ?? 12,
+          maxNegativeBalanceMinutes: oldConfig?.maxNegativeBalanceMinutes ?? null,
+        },
+        newValue: body,
         request: { ip: req.ip, headers: req.headers as Record<string, string> },
       });
-      return { twoFaEnabled };
+      return {
+        twoFaEnabled: config.twoFaEnabled,
+        passwordMinLength: config.passwordMinLength,
+        passwordRequireUpper: config.passwordRequireUpper,
+        passwordRequireLower: config.passwordRequireLower,
+        passwordRequireDigit: config.passwordRequireDigit,
+        passwordRequireSpecial: config.passwordRequireSpecial,
+        maxNegativeBalanceMinutes: config.maxNegativeBalanceMinutes,
+      };
     },
   });
 

--- a/apps/api/src/utils/password-policy.ts
+++ b/apps/api/src/utils/password-policy.ts
@@ -1,0 +1,91 @@
+/**
+ * BSI TR-02102-1 compliant password policy validation.
+ * Policy is configurable per tenant via TenantConfig.
+ */
+import type { FastifyInstance } from "fastify";
+
+export interface PasswordPolicy {
+  passwordMinLength: number;
+  passwordRequireUpper: boolean;
+  passwordRequireLower: boolean;
+  passwordRequireDigit: boolean;
+  passwordRequireSpecial: boolean;
+}
+
+export const DEFAULT_PASSWORD_POLICY: PasswordPolicy = {
+  passwordMinLength: 12,
+  passwordRequireUpper: true,
+  passwordRequireLower: true,
+  passwordRequireDigit: true,
+  passwordRequireSpecial: true,
+};
+
+/** Common German + English passwords that should always be rejected. */
+const BLOCKED_PASSWORDS = new Set([
+  "passwort123",
+  "passwort1!",
+  "password123",
+  "password1!",
+  "hallo12345",
+  "willkommen1",
+  "qwertz1234",
+  "qwerty1234",
+  "12345678ab",
+  "abcdefgh1!",
+  "changeme123",
+  "letmein1234",
+]);
+
+export interface PasswordValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function validatePassword(
+  password: string,
+  policy: PasswordPolicy = DEFAULT_PASSWORD_POLICY,
+): PasswordValidationResult {
+  const errors: string[] = [];
+
+  if (password.length < policy.passwordMinLength) {
+    errors.push(`Mindestens ${policy.passwordMinLength} Zeichen erforderlich`);
+  }
+
+  if (policy.passwordRequireUpper && !/[A-Z]/.test(password)) {
+    errors.push("Mindestens ein Großbuchstabe erforderlich");
+  }
+
+  if (policy.passwordRequireLower && !/[a-z]/.test(password)) {
+    errors.push("Mindestens ein Kleinbuchstabe erforderlich");
+  }
+
+  if (policy.passwordRequireDigit && !/\d/.test(password)) {
+    errors.push("Mindestens eine Ziffer erforderlich");
+  }
+
+  if (policy.passwordRequireSpecial && !/[^A-Za-z0-9]/.test(password)) {
+    errors.push("Mindestens ein Sonderzeichen erforderlich");
+  }
+
+  if (BLOCKED_PASSWORDS.has(password.toLowerCase())) {
+    errors.push("Dieses Passwort ist zu häufig und nicht erlaubt");
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** Load the password policy for a tenant from DB, falling back to defaults. */
+export async function loadPasswordPolicy(
+  app: FastifyInstance,
+  tenantId: string,
+): Promise<PasswordPolicy> {
+  const cfg = await app.prisma.tenantConfig.findUnique({ where: { tenantId } });
+  if (!cfg) return DEFAULT_PASSWORD_POLICY;
+  return {
+    passwordMinLength: cfg.passwordMinLength ?? 12,
+    passwordRequireUpper: cfg.passwordRequireUpper ?? true,
+    passwordRequireLower: cfg.passwordRequireLower ?? true,
+    passwordRequireDigit: cfg.passwordRequireDigit ?? true,
+    passwordRequireSpecial: cfg.passwordRequireSpecial ?? true,
+  };
+}

--- a/apps/web/src/lib/components/ui/PasswordStrength.svelte
+++ b/apps/web/src/lib/components/ui/PasswordStrength.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  interface Props {
+    password: string;
+    policy: {
+      passwordMinLength: number;
+      passwordRequireUpper: boolean;
+      passwordRequireLower: boolean;
+      passwordRequireDigit: boolean;
+      passwordRequireSpecial: boolean;
+    };
+  }
+
+  let { password, policy }: Props = $props();
+
+  let checks = $derived([
+    { label: `Min. ${policy.passwordMinLength} Zeichen`, ok: password.length >= policy.passwordMinLength },
+    ...(policy.passwordRequireUpper ? [{ label: "Großbuchstabe (A-Z)", ok: /[A-Z]/.test(password) }] : []),
+    ...(policy.passwordRequireLower ? [{ label: "Kleinbuchstabe (a-z)", ok: /[a-z]/.test(password) }] : []),
+    ...(policy.passwordRequireDigit ? [{ label: "Ziffer (0-9)", ok: /\d/.test(password) }] : []),
+    ...(policy.passwordRequireSpecial ? [{ label: "Sonderzeichen (!@#...)", ok: /[^A-Za-z0-9]/.test(password) }] : []),
+  ]);
+
+  let passedCount = $derived(checks.filter((c) => c.ok).length);
+  let allPassed = $derived(passedCount === checks.length);
+  let strength = $derived(
+    checks.length === 0 ? 0 : Math.round((passedCount / checks.length) * 100),
+  );
+</script>
+
+{#if password.length > 0}
+  <div class="pw-strength">
+    <div class="pw-bar-track">
+      <div
+        class="pw-bar-fill"
+        class:pw-weak={strength < 50}
+        class:pw-medium={strength >= 50 && strength < 100}
+        class:pw-strong={strength === 100}
+        style="width:{strength}%"
+      ></div>
+    </div>
+    <ul class="pw-checks">
+      {#each checks as c}
+        <li class="pw-check" class:pw-check-ok={c.ok}>
+          <span class="pw-check-icon">{c.ok ? "✓" : "○"}</span>
+          {c.label}
+        </li>
+      {/each}
+    </ul>
+  </div>
+{/if}
+
+<style>
+  .pw-strength {
+    margin-top: 0.5rem;
+  }
+  .pw-bar-track {
+    height: 4px;
+    background: var(--gray-200);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-bottom: 0.5rem;
+  }
+  .pw-bar-fill {
+    height: 100%;
+    border-radius: 2px;
+    transition: width 0.3s ease, background 0.3s ease;
+  }
+  .pw-weak { background: var(--color-red); }
+  .pw-medium { background: var(--color-yellow); }
+  .pw-strong { background: var(--color-green); }
+  .pw-checks {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem 1rem;
+  }
+  .pw-check {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  .pw-check-ok {
+    color: var(--color-green);
+  }
+  .pw-check-icon {
+    font-size: 0.7rem;
+  }
+</style>

--- a/apps/web/src/routes/(app)/admin/system/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/system/+page.svelte
@@ -101,6 +101,23 @@
   let twoFaSaving = $state(false);
   let twoFaError = $state("");
 
+  // Password policy (BSI)
+  let pwMinLength = $state(12);
+  let pwRequireUpper = $state(true);
+  let pwRequireLower = $state(true);
+  let pwRequireDigit = $state(true);
+  let pwRequireSpecial = $state(true);
+  let pwSaving = $state(false);
+  let pwSaved = $state(false);
+  let pwError = $state("");
+
+  // Max negative hours
+  let maxNegEnabled = $state(false);
+  let maxNegHours = $state(20);
+  let maxNegSaving = $state(false);
+  let maxNegSaved = $state(false);
+  let maxNegError = $state("");
+
   // NFC Terminals
   interface TerminalKey {
     id: string;
@@ -179,8 +196,25 @@
       }
 
       try {
-        const sec = await api.get<{ twoFaEnabled: boolean }>("/settings/security");
+        const sec = await api.get<{
+          twoFaEnabled: boolean;
+          passwordMinLength: number;
+          passwordRequireUpper: boolean;
+          passwordRequireLower: boolean;
+          passwordRequireDigit: boolean;
+          passwordRequireSpecial: boolean;
+          maxNegativeBalanceMinutes: number | null;
+        }>("/settings/security");
         twoFaEnabled = sec.twoFaEnabled;
+        pwMinLength = sec.passwordMinLength;
+        pwRequireUpper = sec.passwordRequireUpper;
+        pwRequireLower = sec.passwordRequireLower;
+        pwRequireDigit = sec.passwordRequireDigit;
+        pwRequireSpecial = sec.passwordRequireSpecial;
+        if (sec.maxNegativeBalanceMinutes != null) {
+          maxNegEnabled = true;
+          maxNegHours = sec.maxNegativeBalanceMinutes / 60;
+        }
       } catch {
         /* ignorieren */
       }
@@ -297,6 +331,44 @@
       twoFaError = e instanceof Error ? e.message : "Fehler";
     } finally {
       twoFaSaving = false;
+    }
+  }
+
+  async function savePasswordPolicy() {
+    pwSaving = true;
+    pwSaved = false;
+    pwError = "";
+    try {
+      await api.put("/settings/security", {
+        passwordMinLength: pwMinLength,
+        passwordRequireUpper: pwRequireUpper,
+        passwordRequireLower: pwRequireLower,
+        passwordRequireDigit: pwRequireDigit,
+        passwordRequireSpecial: pwRequireSpecial,
+      });
+      pwSaved = true;
+      setTimeout(() => (pwSaved = false), 3000);
+    } catch (e: unknown) {
+      pwError = e instanceof Error ? e.message : "Fehler";
+    } finally {
+      pwSaving = false;
+    }
+  }
+
+  async function saveMaxNegative() {
+    maxNegSaving = true;
+    maxNegSaved = false;
+    maxNegError = "";
+    try {
+      await api.put("/settings/security", {
+        maxNegativeBalanceMinutes: maxNegEnabled ? Math.round(maxNegHours * 60) : null,
+      });
+      maxNegSaved = true;
+      setTimeout(() => (maxNegSaved = false), 3000);
+    } catch (e: unknown) {
+      maxNegError = e instanceof Error ? e.message : "Fehler";
+    } finally {
+      maxNegSaving = false;
     }
   }
 
@@ -492,6 +564,110 @@
           />
           <span class="switch-slider"></span>
         </label>
+      </div>
+    </div>
+
+    <hr class="sys-divider" />
+
+    <!-- Passwort-Richtlinie (BSI) -->
+    <div class="sys-section">
+      <h3 class="sys-title">Passwort-Richtlinie (BSI)</h3>
+      {#if pwError}
+        <div class="alert alert-error" role="alert" style="margin-bottom:1rem;">
+          <span>⚠</span><span>{pwError}</span>
+        </div>
+      {/if}
+      <div class="settings-grid">
+        <div class="form-group">
+          <label class="form-label" for="pw-min-length">Mindestlänge</label>
+          <input id="pw-min-length" type="number" min="8" max="128" bind:value={pwMinLength} class="form-input" />
+          <p class="form-hint text-muted">BSI empfiehlt mindestens 12 Zeichen.</p>
+        </div>
+      </div>
+      <div class="toggle-row" style="margin-top:0.75rem">
+        <div class="toggle-info">
+          <span class="toggle-row-label">Großbuchstabe erforderlich</span>
+        </div>
+        <label class="switch">
+          <input type="checkbox" bind:checked={pwRequireUpper} />
+          <span class="switch-slider"></span>
+        </label>
+      </div>
+      <div class="toggle-row">
+        <div class="toggle-info">
+          <span class="toggle-row-label">Kleinbuchstabe erforderlich</span>
+        </div>
+        <label class="switch">
+          <input type="checkbox" bind:checked={pwRequireLower} />
+          <span class="switch-slider"></span>
+        </label>
+      </div>
+      <div class="toggle-row">
+        <div class="toggle-info">
+          <span class="toggle-row-label">Ziffer erforderlich</span>
+        </div>
+        <label class="switch">
+          <input type="checkbox" bind:checked={pwRequireDigit} />
+          <span class="switch-slider"></span>
+        </label>
+      </div>
+      <div class="toggle-row">
+        <div class="toggle-info">
+          <span class="toggle-row-label">Sonderzeichen erforderlich</span>
+        </div>
+        <label class="switch">
+          <input type="checkbox" bind:checked={pwRequireSpecial} />
+          <span class="switch-slider"></span>
+        </label>
+      </div>
+      <div class="settings-actions">
+        <button class="btn btn-primary" onclick={savePasswordPolicy} disabled={pwSaving}>
+          {pwSaving ? "Speichern…" : "Speichern"}
+        </button>
+        {#if pwSaved}
+          <span class="saved-hint">✓ Gespeichert</span>
+        {/if}
+      </div>
+    </div>
+
+    <hr class="sys-divider" />
+
+    <!-- Max. Minusstunden -->
+    <div class="sys-section">
+      <h3 class="sys-title">Max. Minusstunden</h3>
+      {#if maxNegError}
+        <div class="alert alert-error" role="alert" style="margin-bottom:1rem;">
+          <span>⚠</span><span>{maxNegError}</span>
+        </div>
+      {/if}
+      <div class="toggle-row">
+        <div class="toggle-info">
+          <span class="toggle-row-label">Limit für negatives Überstundensaldo</span>
+          <p class="form-hint text-muted">
+            Begrenzt, wie viele Minusstunden Mitarbeiter ansammeln dürfen.
+          </p>
+        </div>
+        <label class="switch">
+          <input type="checkbox" bind:checked={maxNegEnabled} />
+          <span class="switch-slider"></span>
+        </label>
+      </div>
+      {#if maxNegEnabled}
+        <div class="settings-grid" style="margin-top:0.75rem">
+          <div class="form-group">
+            <label class="form-label" for="max-neg-hours">Max. Minusstunden (h)</label>
+            <input id="max-neg-hours" type="number" min="1" max="999" step="0.5" bind:value={maxNegHours} class="form-input" />
+            <p class="form-hint text-muted">Pro Mitarbeiter individuell überschreibbar.</p>
+          </div>
+        </div>
+      {/if}
+      <div class="settings-actions">
+        <button class="btn btn-primary" onclick={saveMaxNegative} disabled={maxNegSaving}>
+          {maxNegSaving ? "Speichern…" : "Speichern"}
+        </button>
+        {#if maxNegSaved}
+          <span class="saved-hint">✓ Gespeichert</span>
+        {/if}
       </div>
     </div>
 

--- a/apps/web/src/routes/(auth)/einladung/+page.svelte
+++ b/apps/web/src/routes/(auth)/einladung/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { page } from "$app/state";
   import { api } from "$api/client";
+  import PasswordStrength from "$lib/components/ui/PasswordStrength.svelte";
 
   let token = $state("");
   let password = $state("");
@@ -10,9 +11,21 @@
   let loading = $state(false);
   let pageState = $state<"form" | "success" | "expired" | "used" | "invalid">("form");
 
-  onMount(() => {
+  let pwPolicy = $state({
+    passwordMinLength: 12,
+    passwordRequireUpper: true,
+    passwordRequireLower: true,
+    passwordRequireDigit: true,
+    passwordRequireSpecial: true,
+  });
+
+  onMount(async () => {
     token = page.url.searchParams.get("token") ?? "";
-    if (!token) pageState = "invalid";
+    if (!token) { pageState = "invalid"; return; }
+    try {
+      const p = await api.get<typeof pwPolicy>("/auth/password-policy");
+      pwPolicy = p;
+    } catch { /* use defaults */ }
   });
 
   async function handleSubmit() {
@@ -20,8 +33,8 @@
       error = "Passwörter stimmen nicht überein";
       return;
     }
-    if (password.length < 8) {
-      error = "Passwort muss mindestens 8 Zeichen haben";
+    if (password.length < pwPolicy.passwordMinLength) {
+      error = `Passwort muss mindestens ${pwPolicy.passwordMinLength} Zeichen haben`;
       return;
     }
     loading = true;
@@ -115,9 +128,10 @@
             required
             minlength="8"
             class="form-input"
-            placeholder="Mindestens 8 Zeichen"
+            placeholder="Mindestens {pwPolicy.passwordMinLength} Zeichen"
             autocomplete="new-password"
           />
+          <PasswordStrength {password} policy={pwPolicy} />
         </div>
 
         <div class="form-group">

--- a/apps/web/src/routes/(auth)/reset-password/+page.svelte
+++ b/apps/web/src/routes/(auth)/reset-password/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { preventDefault } from "svelte/legacy";
-
+  import { onMount } from "svelte";
   import { page } from "$app/stores";
   import { api } from "$api/client";
+  import PasswordStrength from "$lib/components/ui/PasswordStrength.svelte";
 
   let password = $state("");
   let confirmPassword = $state("");
@@ -10,9 +11,24 @@
   let loading = $state(false);
   let success = $state(false);
 
+  let pwPolicy = $state({
+    passwordMinLength: 12,
+    passwordRequireUpper: true,
+    passwordRequireLower: true,
+    passwordRequireDigit: true,
+    passwordRequireSpecial: true,
+  });
+
   let token = $derived($page.url.searchParams.get("token") ?? "");
   let passwordMismatch = $derived(confirmPassword.length > 0 && password !== confirmPassword);
-  let canSubmit = $derived(password.length >= 8 && password === confirmPassword && !loading);
+  let canSubmit = $derived(password.length >= pwPolicy.passwordMinLength && password === confirmPassword && !loading);
+
+  onMount(async () => {
+    try {
+      const p = await api.get<typeof pwPolicy>("/auth/password-policy");
+      pwPolicy = p;
+    } catch { /* use defaults */ }
+  });
 
   async function handleSubmit() {
     if (password !== confirmPassword) {
@@ -76,11 +92,12 @@
             type="password"
             bind:value={password}
             required
-            minlength="8"
+            minlength={pwPolicy.passwordMinLength}
             class="form-input"
-            placeholder="Mindestens 8 Zeichen"
+            placeholder="Mindestens {pwPolicy.passwordMinLength} Zeichen"
             autocomplete="new-password"
           />
+          <PasswordStrength {password} policy={pwPolicy} />
         </div>
 
         <div class="form-group">

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -61,7 +61,13 @@ model TenantConfig {
   smtpFromName  String?
   smtpSecure    Boolean  @default(false)
   // Sicherheit
-  twoFaEnabled  Boolean  @default(false)
+  twoFaEnabled           Boolean  @default(false)
+  // Passwort-Richtlinie (BSI TR-02102-1)
+  passwordMinLength      Int      @default(12)
+  passwordRequireUpper   Boolean  @default(true)
+  passwordRequireLower   Boolean  @default(true)
+  passwordRequireDigit   Boolean  @default(true)
+  passwordRequireSpecial Boolean  @default(true)
   // Zeitzone (IANA)
   timezone      String   @default("Europe/Berlin")
   // Phorest-Integration
@@ -85,6 +91,8 @@ model TenantConfig {
   // Überstunden-Jahresübertrag
   overtimeCarryOverMode  String  @default("FULL") // FULL | CAPPED | RESET
   overtimeCarryOverCap   Int?    // Max. Übertrag in Minuten (nur bei CAPPED)
+  // Max. Minusstunden (null = unbegrenzt, Wert in Minuten)
+  maxNegativeBalanceMinutes Int?
   // Aufbewahrungsfrist in Jahren (Minimum 2, Default 10)
   dataRetentionYears     Int     @default(10)
   createdAt            DateTime @default(now()) @db.Timestamptz
@@ -203,6 +211,7 @@ model WorkSchedule {
   sundayHours           Decimal  @db.Decimal(4, 2)  @default(0)
   overtimeThreshold     Decimal  @db.Decimal(5, 2)  @default(60)  // Alert ab X Stunden
   allowOvertimePayout   Boolean  @default(false)
+  maxNegativeBalanceMinutes Int? // Pro-MA Override (null = Tenant-Default)
   validFrom             DateTime @db.Timestamptz
   createdAt             DateTime @default(now()) @db.Timestamptz
   updatedAt             DateTime @updatedAt      @db.Timestamptz


### PR DESCRIPTION
## Summary
- Configurable BSI TR-02102-1 password policy per tenant (min length, complexity requirements, blocked passwords)
- Configurable max negative balance (Minusstunden) per tenant with per-employee override
- Real-time password strength indicator on invitation and reset pages

Closes #25, closes #48

## Changes
- **Schema**: TenantConfig +7 fields (password policy + maxNegativeBalanceMinutes), WorkSchedule +1 field
- **API**: New `utils/password-policy.ts`, validation in auth/employees/invitations, extended security settings + overtime response
- **Frontend**: PasswordStrength component, admin system page sections, policy-aware invitation/reset pages

## Test plan
- [ ] Admin > System: Password policy section visible, save works
- [ ] Admin > System: Max Minusstunden toggle + hours input, save works
- [ ] Create employee with weak password → error
- [ ] Accept invitation with password strength indicator visible
- [ ] Reset password with strength indicator visible
- [ ] Overtime page shows warning when negative limit exceeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)