### PR TITLE
feat: special leave rules (Sonderurlaub) with statutory defaults

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -31,6 +31,7 @@ import { shiftRoutes } from "./routes/shifts";
 import { integrationRoutes } from "./routes/integrations";
 import { importRoutes } from "./routes/imports";
 import { terminalRoutes } from "./routes/terminals";
+import { specialLeaveRoutes } from "./routes/special-leave";
 
 export async function buildApp() {
   const app = Fastify({
@@ -143,6 +144,7 @@ export async function buildApp() {
   await app.register(integrationRoutes, { prefix: "/api/v1/integrations" });
   await app.register(importRoutes, { prefix: "/api/v1/imports" });
   await app.register(terminalRoutes, { prefix: "/api/v1/terminals" });
+  await app.register(specialLeaveRoutes, { prefix: "/api/v1/special-leave" });
 
   // ── Health ────────────────────────────────────────────────
   app.get("/health", async () => ({ status: "ok", timestamp: new Date().toISOString() }));

--- a/apps/api/src/routes/leave.ts
+++ b/apps/api/src/routes/leave.ts
@@ -78,6 +78,7 @@ const createSchema = z
       .refine((s) => !isNaN(new Date(s).getTime()), "Ungültiges Datum"),
     halfDay: z.boolean().default(false),
     note: z.string().optional().nullable(),
+    specialLeaveRuleId: z.string().uuid().optional().nullable(),
   })
   .refine((data) => new Date(data.startDate) <= new Date(data.endDate), {
     message: "Enddatum muss nach Startdatum liegen",
@@ -258,10 +259,29 @@ export async function leaveRoutes(app: FastifyInstance) {
         }
       }
 
+      // Für SPECIAL: specialLeaveRuleId required, validate days against rule
+      if (body.type === "SPECIAL") {
+        if (!body.specialLeaveRuleId) {
+          return reply.code(400).send({ error: "Sonderurlaub erfordert einen Anlass (specialLeaveRuleId)" });
+        }
+        const rule = await app.prisma.specialLeaveRule.findUnique({
+          where: { id: body.specialLeaveRuleId },
+        });
+        if (!rule || !rule.isActive) {
+          return reply.code(400).send({ error: "Ungültiger oder deaktivierter Sonderurlaubs-Anlass" });
+        }
+        if (days > Number(rule.defaultDays)) {
+          return reply.code(400).send({
+            error: `Max. ${Number(rule.defaultDays)} Tage für "${rule.name}" (beantragt: ${days})`,
+          });
+        }
+      }
+
       const request = await app.prisma.leaveRequest.create({
         data: {
           employeeId,
           leaveTypeId,
+          specialLeaveRuleId: body.specialLeaveRuleId ?? null,
           startDate: start,
           endDate: end,
           days,

--- a/apps/api/src/routes/special-leave.ts
+++ b/apps/api/src/routes/special-leave.ts
@@ -1,0 +1,174 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { requireAuth, requireRole } from "../middleware/auth";
+
+/** Statutory special leave defaults per § 616 BGB / common collective agreements. */
+const STATUTORY_DEFAULTS = [
+  { name: "Eigene Hochzeit", defaultDays: 1, requiresProof: true },
+  { name: "Geburt eines Kindes", defaultDays: 1, requiresProof: true },
+  { name: "Tod Ehepartner/Lebenspartner", defaultDays: 2, requiresProof: true },
+  { name: "Tod Elternteil/Kind", defaultDays: 2, requiresProof: true },
+  { name: "Tod Geschwister", defaultDays: 1, requiresProof: true },
+  { name: "Tod Schwiegereltern", defaultDays: 1, requiresProof: true },
+  { name: "Schwere Erkrankung Hausangehöriger", defaultDays: 1, requiresProof: false },
+  { name: "Umzug (betriebsbedingt)", defaultDays: 1, requiresProof: false },
+  { name: "Silberne Hochzeit", defaultDays: 1, requiresProof: false },
+  { name: "Goldene Hochzeit", defaultDays: 1, requiresProof: false },
+  { name: "25-jähriges Dienstjubiläum", defaultDays: 1, requiresProof: false },
+];
+
+/** Ensure statutory default rules exist for a tenant (lazy seeding). */
+async function ensureStatutoryRules(prisma: any, tenantId: string) {
+  const existing = await prisma.specialLeaveRule.findMany({
+    where: { tenantId, isStatutory: true },
+  });
+  if (existing.length > 0) return;
+
+  for (const def of STATUTORY_DEFAULTS) {
+    await prisma.specialLeaveRule.upsert({
+      where: { tenantId_name: { tenantId, name: def.name } },
+      update: {},
+      create: {
+        tenantId,
+        name: def.name,
+        reason: `Gesetzlicher Anspruch gemäß § 616 BGB`,
+        defaultDays: def.defaultDays,
+        isStatutory: true,
+        requiresProof: def.requiresProof,
+        isActive: true,
+      },
+    });
+  }
+}
+
+const createRuleSchema = z.object({
+  name: z.string().min(1).max(100),
+  reason: z.string().max(500).optional(),
+  defaultDays: z.number().min(0.5).max(30),
+  requiresProof: z.boolean().default(false),
+});
+
+const updateRuleSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  reason: z.string().max(500).nullable().optional(),
+  defaultDays: z.number().min(0.5).max(30).optional(),
+  requiresProof: z.boolean().optional(),
+  isActive: z.boolean().optional(),
+});
+
+export async function specialLeaveRoutes(app: FastifyInstance) {
+  // GET /api/v1/special-leave/rules
+  app.get("/rules", {
+    schema: { tags: ["Sonderurlaub"], security: [{ bearerAuth: [] }] },
+    preHandler: requireAuth,
+    handler: async (req) => {
+      const tenantId = req.user.tenantId;
+      await ensureStatutoryRules(app.prisma, tenantId);
+
+      const rules = await app.prisma.specialLeaveRule.findMany({
+        where: { tenantId },
+        orderBy: [{ isStatutory: "desc" }, { name: "asc" }],
+      });
+      return rules;
+    },
+  });
+
+  // POST /api/v1/special-leave/rules — custom rule (admin only)
+  app.post("/rules", {
+    schema: { tags: ["Sonderurlaub"], security: [{ bearerAuth: [] }] },
+    preHandler: requireRole("ADMIN"),
+    handler: async (req, reply) => {
+      const body = createRuleSchema.parse(req.body);
+      const tenantId = req.user.tenantId;
+
+      const rule = await app.prisma.specialLeaveRule.create({
+        data: {
+          tenantId,
+          name: body.name,
+          reason: body.reason,
+          defaultDays: body.defaultDays,
+          requiresProof: body.requiresProof,
+          isStatutory: false,
+          isActive: true,
+        },
+      });
+
+      await app.audit({
+        userId: req.user.sub,
+        action: "CREATE",
+        entity: "SpecialLeaveRule",
+        entityId: rule.id,
+        newValue: body,
+        request: { ip: req.ip, headers: req.headers as Record<string, string> },
+      });
+
+      return rule;
+    },
+  });
+
+  // PUT /api/v1/special-leave/rules/:id
+  app.put("/rules/:id", {
+    schema: { tags: ["Sonderurlaub"], security: [{ bearerAuth: [] }] },
+    preHandler: requireRole("ADMIN"),
+    handler: async (req, reply) => {
+      const { id } = req.params as { id: string };
+      const body = updateRuleSchema.parse(req.body);
+
+      const existing = await app.prisma.specialLeaveRule.findUnique({ where: { id } });
+      if (!existing) return reply.code(404).send({ error: "Regel nicht gefunden" });
+
+      // Statutory rules: name cannot be changed
+      if (existing.isStatutory && body.name && body.name !== existing.name) {
+        return reply.code(400).send({ error: "Name gesetzlicher Regeln kann nicht geändert werden" });
+      }
+
+      const updated = await app.prisma.specialLeaveRule.update({
+        where: { id },
+        data: body,
+      });
+
+      await app.audit({
+        userId: req.user.sub,
+        action: "UPDATE",
+        entity: "SpecialLeaveRule",
+        entityId: id,
+        oldValue: { defaultDays: Number(existing.defaultDays), isActive: existing.isActive },
+        newValue: body,
+        request: { ip: req.ip, headers: req.headers as Record<string, string> },
+      });
+
+      return updated;
+    },
+  });
+
+  // DELETE /api/v1/special-leave/rules/:id — only custom rules
+  app.delete("/rules/:id", {
+    schema: { tags: ["Sonderurlaub"], security: [{ bearerAuth: [] }] },
+    preHandler: requireRole("ADMIN"),
+    handler: async (req, reply) => {
+      const { id } = req.params as { id: string };
+
+      const existing = await app.prisma.specialLeaveRule.findUnique({ where: { id } });
+      if (!existing) return reply.code(404).send({ error: "Regel nicht gefunden" });
+
+      if (existing.isStatutory) {
+        return reply.code(400).send({
+          error: "Gesetzliche Regeln können nicht gelöscht werden — nur deaktiviert",
+        });
+      }
+
+      await app.prisma.specialLeaveRule.delete({ where: { id } });
+
+      await app.audit({
+        userId: req.user.sub,
+        action: "DELETE",
+        entity: "SpecialLeaveRule",
+        entityId: id,
+        oldValue: { name: existing.name },
+        request: { ip: req.ip, headers: req.headers as Record<string, string> },
+      });
+
+      return { success: true };
+    },
+  });
+}

--- a/apps/web/src/routes/(app)/admin/+layout.svelte
+++ b/apps/web/src/routes/(app)/admin/+layout.svelte
@@ -25,6 +25,7 @@
       { href: "/admin/employees", label: "Mitarbeiter", show: true },
       { href: "/admin/vacation", label: "Urlaub & Zeiten", show: true },
       { href: "/admin/shifts", label: "Schichtplan", show: isManager },
+      { href: "/admin/special-leave", label: "Sonderurlaub", show: true },
       { href: "/admin/shutdowns", label: "Betriebsurlaub", show: true },
       { href: "/admin/monatsabschluss", label: "Monatsabschluss", show: isManager },
       { href: "/admin/system", label: "System", show: true },

--- a/apps/web/src/routes/(app)/admin/special-leave/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/special-leave/+page.svelte
@@ -1,0 +1,318 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { api } from "$api/client";
+  import Breadcrumb from "$lib/components/ui/Breadcrumb.svelte";
+  import { toasts } from "$stores/toast";
+
+  interface SpecialLeaveRule {
+    id: string;
+    name: string;
+    reason: string | null;
+    defaultDays: number;
+    isStatutory: boolean;
+    requiresProof: boolean;
+    isActive: boolean;
+  }
+
+  let rules: SpecialLeaveRule[] = $state([]);
+  let loading = $state(true);
+
+  // Create modal
+  let showCreate = $state(false);
+  let createName = $state("");
+  let createReason = $state("");
+  let createDays = $state(1);
+  let createProof = $state(false);
+  let creating = $state(false);
+
+  // Edit modal
+  let editRule: SpecialLeaveRule | null = $state(null);
+  let editDays = $state(1);
+  let editProof = $state(false);
+  let editActive = $state(true);
+  let editReason = $state("");
+  let saving = $state(false);
+
+  onMount(loadRules);
+
+  async function loadRules() {
+    loading = true;
+    try {
+      rules = await api.get<SpecialLeaveRule[]>("/special-leave/rules");
+    } catch (e) {
+      toasts.error("Fehler beim Laden der Sonderurlaubsregeln");
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function handleCreate() {
+    if (!createName.trim()) return;
+    creating = true;
+    try {
+      await api.post("/special-leave/rules", {
+        name: createName.trim(),
+        reason: createReason.trim() || undefined,
+        defaultDays: createDays,
+        requiresProof: createProof,
+      });
+      showCreate = false;
+      createName = "";
+      createReason = "";
+      createDays = 1;
+      createProof = false;
+      await loadRules();
+      toasts.success("Regel erstellt");
+    } catch (e: unknown) {
+      toasts.error(e instanceof Error ? e.message : "Fehler");
+    } finally {
+      creating = false;
+    }
+  }
+
+  function openEdit(rule: SpecialLeaveRule) {
+    editRule = rule;
+    editDays = Number(rule.defaultDays);
+    editProof = rule.requiresProof;
+    editActive = rule.isActive;
+    editReason = rule.reason ?? "";
+  }
+
+  async function handleSave() {
+    if (!editRule) return;
+    saving = true;
+    try {
+      await api.put(`/special-leave/rules/${editRule.id}`, {
+        defaultDays: editDays,
+        requiresProof: editProof,
+        isActive: editActive,
+        reason: editReason.trim() || null,
+      });
+      editRule = null;
+      await loadRules();
+      toasts.success("Regel aktualisiert");
+    } catch (e: unknown) {
+      toasts.error(e instanceof Error ? e.message : "Fehler");
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function handleDelete(rule: SpecialLeaveRule) {
+    if (rule.isStatutory) return;
+    try {
+      await api.delete(`/special-leave/rules/${rule.id}`);
+      await loadRules();
+      toasts.success("Regel gelöscht");
+    } catch (e: unknown) {
+      toasts.error(e instanceof Error ? e.message : "Fehler");
+    }
+  }
+</script>
+
+<Breadcrumb items={[{ label: "Admin", href: "/admin" }, { label: "Sonderurlaub" }]} />
+
+<div class="page-header">
+  <h1 class="page-title">Sonderurlaubsregeln</h1>
+  <button class="btn btn-primary" onclick={() => (showCreate = true)}>+ Neue Regel</button>
+</div>
+
+<p class="text-muted" style="margin-bottom:1.5rem;">
+  Gesetzliche Anlässe (§ 616 BGB) werden automatisch angelegt. Tage und Nachweis­pflicht
+  können angepasst, zusätzliche betriebliche Anlässe hinzugefügt werden.
+</p>
+
+{#if loading}
+  <p class="text-muted">Laden…</p>
+{:else}
+  <div class="table-wrap">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Anlass</th>
+          <th>Tage</th>
+          <th>Nachweis</th>
+          <th>Art</th>
+          <th>Status</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each rules as rule}
+          <tr class:inactive={!rule.isActive}>
+            <td>
+              <strong>{rule.name}</strong>
+              {#if rule.reason}
+                <br /><span class="text-muted text-sm">{rule.reason}</span>
+              {/if}
+            </td>
+            <td>{Number(rule.defaultDays)}</td>
+            <td>{rule.requiresProof ? "Ja" : "Nein"}</td>
+            <td>
+              <span class="badge" class:badge-statutory={rule.isStatutory} class:badge-custom={!rule.isStatutory}>
+                {rule.isStatutory ? "Gesetzlich" : "Betrieblich"}
+              </span>
+            </td>
+            <td>
+              <span class="status-dot" class:active={rule.isActive} class:deactivated={!rule.isActive}></span>
+              {rule.isActive ? "Aktiv" : "Deaktiviert"}
+            </td>
+            <td class="actions-cell">
+              <button class="btn btn-ghost btn-sm" onclick={() => openEdit(rule)}>Bearbeiten</button>
+              {#if !rule.isStatutory}
+                <button class="btn btn-ghost btn-sm text-danger" onclick={() => handleDelete(rule)}>Löschen</button>
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+{/if}
+
+<!-- Create Modal -->
+{#if showCreate}
+  <div class="modal-backdrop" onclick={() => (showCreate = false)} role="presentation">
+    <div class="modal" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+      <div class="modal-header">
+        <h2 class="modal-title">Neue Sonderurlaubsregel</h2>
+        <button class="modal-close" onclick={() => (showCreate = false)}>✕</button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-label" for="cr-name">Anlass</label>
+          <input id="cr-name" class="form-input" bind:value={createName} placeholder="z. B. Ehrenamtlicher Einsatz" />
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="cr-reason">Beschreibung</label>
+          <input id="cr-reason" class="form-input" bind:value={createReason} placeholder="Optional" />
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="cr-days">Tage</label>
+          <input id="cr-days" type="number" class="form-input" min="0.5" max="30" step="0.5" bind:value={createDays} />
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-row-label">Nachweis erforderlich</span>
+          <label class="switch">
+            <input type="checkbox" bind:checked={createProof} />
+            <span class="switch-slider"></span>
+          </label>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-ghost" onclick={() => (showCreate = false)}>Abbrechen</button>
+        <button class="btn btn-primary" onclick={handleCreate} disabled={creating || !createName.trim()}>
+          {creating ? "Erstellen…" : "Erstellen"}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- Edit Modal -->
+{#if editRule}
+  <div class="modal-backdrop" onclick={() => (editRule = null)} role="presentation">
+    <div class="modal" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+      <div class="modal-header">
+        <h2 class="modal-title">{editRule.name}</h2>
+        <button class="modal-close" onclick={() => (editRule = null)}>✕</button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label class="form-label" for="ed-reason">Beschreibung</label>
+          <input id="ed-reason" class="form-input" bind:value={editReason} />
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="ed-days">Tage</label>
+          <input id="ed-days" type="number" class="form-input" min="0.5" max="30" step="0.5" bind:value={editDays} />
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-row-label">Nachweis erforderlich</span>
+          <label class="switch">
+            <input type="checkbox" bind:checked={editProof} />
+            <span class="switch-slider"></span>
+          </label>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-row-label">Aktiv</span>
+          <label class="switch">
+            <input type="checkbox" bind:checked={editActive} />
+            <span class="switch-slider"></span>
+          </label>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-ghost" onclick={() => (editRule = null)}>Abbrechen</button>
+        <button class="btn btn-primary" onclick={handleSave} disabled={saving}>
+          {saving ? "Speichern…" : "Speichern"}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+  .page-title {
+    font-size: 1.375rem;
+    font-weight: 700;
+  }
+
+  .table-wrap { overflow-x: auto; }
+  .table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+  .table th {
+    text-align: left;
+    padding: 0.625rem 0.75rem;
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+    border-bottom: 2px solid var(--color-border);
+  }
+  .table td {
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--color-border-subtle);
+    vertical-align: middle;
+  }
+  tr.inactive td { opacity: 0.5; }
+  .text-sm { font-size: 0.8125rem; }
+
+  .badge {
+    display: inline-block;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+  .badge-statutory { background: var(--color-blue-bg); color: var(--color-blue); }
+  .badge-custom { background: var(--color-purple-bg); color: var(--color-purple); }
+
+  .status-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-right: 0.25rem;
+  }
+  .status-dot.active { background: var(--color-green); }
+  .status-dot.deactivated { background: var(--gray-400); }
+
+  .actions-cell {
+    text-align: right;
+    white-space: nowrap;
+  }
+  .text-danger { color: var(--color-red) !important; }
+
+  .toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0;
+  }
+</style>

--- a/apps/web/src/routes/(app)/leave/+page.svelte
+++ b/apps/web/src/routes/(app)/leave/+page.svelte
@@ -85,6 +85,11 @@
   let formSaving = $state(false);
   let formError = $state("");
 
+  // Special leave rules
+  interface SpecialLeaveRule { id: string; name: string; defaultDays: number; isActive: boolean; }
+  let specialLeaveRules: SpecialLeaveRule[] = $state([]);
+  let formSpecialRuleId = $state("");
+
   // Überstunden- / Urlaubskontostand
   let overtimeBalance: number | null = $state(null);
   let vacationBalance = $state<{
@@ -506,12 +511,21 @@
   }
 
   // ── Formular zurücksetzen ─────────────────────────────────────────────────
+  async function loadSpecialLeaveRules() {
+    if (specialLeaveRules.length > 0) return;
+    try {
+      const all = await api.get<SpecialLeaveRule[]>("/special-leave/rules");
+      specialLeaveRules = all.filter((r) => r.isActive);
+    } catch { /* ignore */ }
+  }
+
   function resetForm() {
     showForm = false;
     editingRequest = null;
     formType = "VACATION";
     formStart = formEnd = formNote = "";
     formHalfDay = false;
+    formSpecialRuleId = "";
     overlapEntries = [];
     hoursPreview = null;
     serverDays = null;
@@ -536,6 +550,7 @@
           endDate: formEnd,
           halfDay: formHalfDay,
           note: formNote || null,
+          ...(formType === "SPECIAL" && formSpecialRuleId ? { specialLeaveRuleId: formSpecialRuleId } : {}),
         });
       }
       resetForm();
@@ -894,12 +909,25 @@
     <form onsubmit={preventDefault(submitRequest)} class="form-grid">
       <div class="form-group">
         <label class="form-label" for="f-type">Art der Abwesenheit</label>
-        <select id="f-type" bind:value={formType} class="form-input" disabled={!!editingRequest}>
+        <select id="f-type" bind:value={formType} class="form-input" disabled={!!editingRequest}
+          onchange={() => { if (formType === "SPECIAL") loadSpecialLeaveRules(); }}>
           {#each TYPE_OPTIONS as t}
             <option value={t.code}>{t.label}</option>
           {/each}
         </select>
       </div>
+
+      {#if formType === "SPECIAL"}
+        <div class="form-group">
+          <label class="form-label" for="f-special-rule">Anlass</label>
+          <select id="f-special-rule" bind:value={formSpecialRuleId} class="form-input" required>
+            <option value="">— Anlass wählen —</option>
+            {#each specialLeaveRules as rule}
+              <option value={rule.id}>{rule.name} ({Number(rule.defaultDays)} Tage)</option>
+            {/each}
+          </select>
+        </div>
+      {/if}
 
       <div class="form-group">
         <label class="form-label" for="f-start">Von</label>

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -19,13 +19,14 @@ model Tenant {
   createdAt    DateTime @default(now()) @db.Timestamptz
   updatedAt    DateTime @updatedAt    @db.Timestamptz
 
-  employees        Employee[]
-  leaveTypes       LeaveType[]
-  publicHolidays   PublicHoliday[]
-  config           TenantConfig?
-  companyShutdowns CompanyShutdown[]
-  shiftTemplates   ShiftTemplate[]
-  terminalApiKeys  TerminalApiKey[]
+  employees         Employee[]
+  leaveTypes        LeaveType[]
+  publicHolidays    PublicHoliday[]
+  config            TenantConfig?
+  companyShutdowns  CompanyShutdown[]
+  shiftTemplates    ShiftTemplate[]
+  terminalApiKeys   TerminalApiKey[]
+  specialLeaveRules SpecialLeaveRule[]
 }
 
 // ─────────────────────────────────────────────
@@ -394,10 +395,30 @@ model LeaveEntitlement {
   @@index([leaveTypeId])
 }
 
+model SpecialLeaveRule {
+  id            String   @id @default(uuid())
+  tenantId      String
+  name          String   // e.g. "Hochzeit", "Geburt eines Kindes"
+  reason        String?  // Description / display text
+  defaultDays   Decimal  @db.Decimal(4, 2) @default(1) // Default entitlement days
+  isStatutory   Boolean  @default(false) // § 616 BGB (cannot be deleted, only deactivated)
+  requiresProof Boolean  @default(false)
+  isActive      Boolean  @default(true)
+  createdAt     DateTime @default(now()) @db.Timestamptz
+  updatedAt     DateTime @updatedAt      @db.Timestamptz
+
+  tenant        Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  leaveRequests LeaveRequest[]
+
+  @@unique([tenantId, name])
+  @@index([tenantId])
+}
+
 model LeaveRequest {
   id           String             @id @default(uuid())
   employeeId   String
   leaveTypeId  String
+  specialLeaveRuleId String?     // For SPECIAL type: which rule applies
   startDate    DateTime           @db.Date
   endDate      DateTime           @db.Date
   days         Decimal            @db.Decimal(5, 2)
@@ -415,8 +436,9 @@ model LeaveRequest {
   createdAt    DateTime           @default(now()) @db.Timestamptz
   updatedAt    DateTime           @updatedAt      @db.Timestamptz
 
-  employee     Employee           @relation(fields: [employeeId], references: [id], onDelete: Restrict)
-  leaveType    LeaveType          @relation(fields: [leaveTypeId], references: [id], onDelete: Restrict)
+  employee         Employee           @relation(fields: [employeeId], references: [id], onDelete: Restrict)
+  leaveType        LeaveType          @relation(fields: [leaveTypeId], references: [id], onDelete: Restrict)
+  specialLeaveRule SpecialLeaveRule?  @relation(fields: [specialLeaveRuleId], references: [id])
 
   @@index([employeeId])
   @@index([employeeId, status])


### PR DESCRIPTION
## Summary
- New SpecialLeaveRule system with 11 statutory defaults per § 616 BGB (marriage, child birth, death, relocation, etc.)
- Full CRUD API with protection for statutory rules (can deactivate, not delete)
- Admin page for managing rules, leave form dropdown for SPECIAL type requests

Closes #45

## Changes
- **Schema**: New `SpecialLeaveRule` model, `LeaveRequest.specialLeaveRuleId` relation
- **API**: `routes/special-leave.ts` (CRUD + auto-seed), `routes/leave.ts` (SPECIAL validation)
- **Frontend**: New `/admin/special-leave` page, admin layout tab, leave form rule dropdown

## Test plan
- [ ] Admin > Sonderurlaub: statutory rules auto-created on first load
- [ ] Edit statutory rule (days, proof, active) → works
- [ ] Try delete statutory rule → blocked with error
- [ ] Create custom rule → works
- [ ] Delete custom rule → works
- [ ] Leave form: select SPECIAL → rule dropdown appears
- [ ] Submit SPECIAL without rule → error
- [ ] Submit SPECIAL exceeding max days → error

🤖 Generated with [Claude Code](https://claude.com/claude-code)