### PR TITLE
feat: email notifications + move leave config to vacation tab

### DIFF
--- a/apps/api/src/plugins/notify.ts
+++ b/apps/api/src/plugins/notify.ts
@@ -6,7 +6,20 @@ interface NotifyParams {
   title: string;
   message: string;
   link?: string;
+  tenantId?: string; // Required for email dispatch
 }
+
+/** Map notification types to TenantConfig email toggle field names. */
+const EMAIL_TYPE_MAP: Record<string, string> = {
+  LEAVE_REQUEST: "emailOnLeaveRequest",
+  LEAVE_APPROVED: "emailOnLeaveDecision",
+  LEAVE_REJECTED: "emailOnLeaveDecision",
+  LEAVE_CANCELLED: "emailOnLeaveDecision",
+  OVERTIME_WARNING: "emailOnOvertimeWarning",
+  MISSING_ENTRY: "emailOnMissingEntries",
+  CLOCK_OUT_REMINDER: "emailOnClockOutReminder",
+  MONTH_CLOSED: "emailOnMonthClose",
+};
 
 declare module "fastify" {
   interface FastifyInstance {
@@ -15,9 +28,75 @@ declare module "fastify" {
 }
 
 export const notifyPlugin = fp(async (app) => {
-  async function notify({ userId, type, title, message, link }: NotifyParams) {
+  const appUrl = (process.env.APP_URL ?? "http://localhost:5173").replace(/\/$/, "");
+
+  async function notify({ userId, type, title, message, link, tenantId }: NotifyParams) {
+    // 1. Always create in-app notification
     await app.prisma.notification.create({
       data: { userId, type, title, message, link },
+    });
+
+    // 2. Attempt email dispatch (fire-and-forget)
+    if (tenantId) {
+      sendEmailNotification({ userId, type, title, message, link, tenantId }).catch((err) => {
+        app.log.warn({ err, userId, type }, "Failed to send notification email");
+      });
+    }
+  }
+
+  async function sendEmailNotification({
+    userId,
+    type,
+    title,
+    message,
+    link,
+    tenantId,
+  }: Required<Pick<NotifyParams, "userId" | "type" | "title" | "message" | "tenantId">> & { link?: string }) {
+    // Check tenant master switch
+    const config = await app.prisma.tenantConfig.findUnique({ where: { tenantId } });
+    if (!config?.emailNotificationsEnabled) return;
+
+    // Check per-type toggle
+    const toggleField = EMAIL_TYPE_MAP[type];
+    if (toggleField && !(config as any)[toggleField]) return;
+
+    // Check user opt-in
+    const user = await app.prisma.user.findUnique({ where: { id: userId } });
+    if (!user || !user.emailNotifications) return;
+
+    // Check SMTP configured
+    const smtpConfig = await app.mailer.getSmtpConfig(tenantId);
+    if (!smtpConfig) return;
+
+    // Get user's name
+    const employee = await app.prisma.employee.findFirst({ where: { userId } });
+    const firstName = employee?.firstName ?? "Nutzer";
+
+    // Build full link
+    const fullLink = link ? (link.startsWith("http") ? link : `${appUrl}${link}`) : null;
+
+    // Send via nodemailer
+    const nodemailer = await import("nodemailer");
+    const transporter = nodemailer.createTransport({
+      host: smtpConfig.smtpHost,
+      port: smtpConfig.smtpPort,
+      secure: smtpConfig.smtpSecure,
+      auth: { user: smtpConfig.smtpUser, pass: smtpConfig.smtpPassword },
+    });
+
+    await transporter.sendMail({
+      from: `"${smtpConfig.smtpFromName}" <${smtpConfig.smtpFromEmail}>`,
+      to: user.email,
+      subject: `${title} – Clokr`,
+      html: `
+        <div style="font-family:sans-serif;max-width:520px;margin:0 auto;padding:24px">
+          <h2 style="color:#2563eb">${title}</h2>
+          <p>Hallo ${firstName},</p>
+          <p>${message}</p>
+          ${fullLink ? `<a href="${fullLink}" style="display:inline-block;margin:16px 0;padding:12px 24px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px;font-weight:600">Jetzt ansehen</a>` : ""}
+          <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0">
+          <p style="color:#9ca3af;font-size:12px">Diese E-Mail wurde automatisch von Clokr gesendet.</p>
+        </div>`,
     });
   }
 

--- a/apps/api/src/routes/leave.ts
+++ b/apps/api/src/routes/leave.ts
@@ -319,6 +319,7 @@ export async function leaveRoutes(app: FastifyInstance) {
           title: "Neuer Urlaubsantrag",
           message: `${request.employee.firstName} ${request.employee.lastName} hat einen ${typeDef.name}-Antrag gestellt (${body.startDate} – ${body.endDate})`,
           link: `/leave?request=${request.id}`,
+          tenantId,
         });
       }
 
@@ -679,6 +680,7 @@ export async function leaveRoutes(app: FastifyInstance) {
           title: body.status === "APPROVED" ? "Antrag genehmigt" : "Antrag abgelehnt",
           message: `Ihr ${existing.leaveType.name}-Antrag wurde ${body.status === "APPROVED" ? "genehmigt" : "abgelehnt"}.`,
           link: `/leave?request=${existing.id}`,
+          tenantId: requestEmployee.tenantId,
         });
       }
 

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -513,6 +513,13 @@ export async function settingsRoutes(app: FastifyInstance) {
         passwordRequireDigit: cfg?.passwordRequireDigit ?? true,
         passwordRequireSpecial: cfg?.passwordRequireSpecial ?? true,
         maxNegativeBalanceMinutes: cfg?.maxNegativeBalanceMinutes ?? null,
+        emailNotificationsEnabled: cfg?.emailNotificationsEnabled ?? false,
+        emailOnLeaveRequest: cfg?.emailOnLeaveRequest ?? true,
+        emailOnLeaveDecision: cfg?.emailOnLeaveDecision ?? true,
+        emailOnOvertimeWarning: cfg?.emailOnOvertimeWarning ?? false,
+        emailOnMissingEntries: cfg?.emailOnMissingEntries ?? false,
+        emailOnClockOutReminder: cfg?.emailOnClockOutReminder ?? false,
+        emailOnMonthClose: cfg?.emailOnMonthClose ?? true,
       };
     },
   });
@@ -530,6 +537,13 @@ export async function settingsRoutes(app: FastifyInstance) {
         passwordRequireDigit: z.boolean().optional(),
         passwordRequireSpecial: z.boolean().optional(),
         maxNegativeBalanceMinutes: z.number().int().min(0).nullable().optional(),
+        emailNotificationsEnabled: z.boolean().optional(),
+        emailOnLeaveRequest: z.boolean().optional(),
+        emailOnLeaveDecision: z.boolean().optional(),
+        emailOnOvertimeWarning: z.boolean().optional(),
+        emailOnMissingEntries: z.boolean().optional(),
+        emailOnClockOutReminder: z.boolean().optional(),
+        emailOnMonthClose: z.boolean().optional(),
       }).parse(req.body);
       const tenantId = await getTenantId(app, req.user.sub);
       const oldConfig = await app.prisma.tenantConfig.findUnique({ where: { tenantId } });
@@ -559,6 +573,13 @@ export async function settingsRoutes(app: FastifyInstance) {
         passwordRequireDigit: config.passwordRequireDigit,
         passwordRequireSpecial: config.passwordRequireSpecial,
         maxNegativeBalanceMinutes: config.maxNegativeBalanceMinutes,
+        emailNotificationsEnabled: config.emailNotificationsEnabled,
+        emailOnLeaveRequest: config.emailOnLeaveRequest,
+        emailOnLeaveDecision: config.emailOnLeaveDecision,
+        emailOnOvertimeWarning: config.emailOnOvertimeWarning,
+        emailOnMissingEntries: config.emailOnMissingEntries,
+        emailOnClockOutReminder: config.emailOnClockOutReminder,
+        emailOnMonthClose: config.emailOnMonthClose,
       };
     },
   });

--- a/apps/web/src/routes/(app)/admin/system/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/system/+page.svelte
@@ -136,6 +136,18 @@
   let autoCalcPartTimeVacation = $state(true);
   let fullTimeWorkDaysPerWeek = $state(5);
 
+  // E-Mail-Benachrichtigungen
+  let emailEnabled = $state(false);
+  let emailOnLeaveRequest = $state(true);
+  let emailOnLeaveDecision = $state(true);
+  let emailOnOvertimeWarning = $state(false);
+  let emailOnMissingEntries = $state(false);
+  let emailOnClockOutReminder = $state(false);
+  let emailOnMonthClose = $state(true);
+  let emailSaving = $state(false);
+  let emailSaved = $state(false);
+  let emailError = $state("");
+
   // NFC Terminals
   interface TerminalKey {
     id: string;
@@ -244,6 +256,13 @@
           maxNegEnabled = true;
           maxNegHours = sec.maxNegativeBalanceMinutes / 60;
         }
+        emailEnabled = (sec as any).emailNotificationsEnabled ?? false;
+        emailOnLeaveRequest = (sec as any).emailOnLeaveRequest ?? true;
+        emailOnLeaveDecision = (sec as any).emailOnLeaveDecision ?? true;
+        emailOnOvertimeWarning = (sec as any).emailOnOvertimeWarning ?? false;
+        emailOnMissingEntries = (sec as any).emailOnMissingEntries ?? false;
+        emailOnClockOutReminder = (sec as any).emailOnClockOutReminder ?? false;
+        emailOnMonthClose = (sec as any).emailOnMonthClose ?? true;
       } catch {
         /* ignorieren */
       }
@@ -398,6 +417,29 @@
       maxNegError = e instanceof Error ? e.message : "Fehler";
     } finally {
       maxNegSaving = false;
+    }
+  }
+
+  async function saveEmailConfig() {
+    emailSaving = true;
+    emailSaved = false;
+    emailError = "";
+    try {
+      await api.put("/settings/security", {
+        emailNotificationsEnabled: emailEnabled,
+        emailOnLeaveRequest,
+        emailOnLeaveDecision,
+        emailOnOvertimeWarning,
+        emailOnMissingEntries,
+        emailOnClockOutReminder,
+        emailOnMonthClose,
+      });
+      emailSaved = true;
+      setTimeout(() => (emailSaved = false), 3000);
+    } catch (e: unknown) {
+      emailError = e instanceof Error ? e.message : "Fehler";
+    } finally {
+      emailSaving = false;
     }
   }
 
@@ -686,148 +728,58 @@
 
     <hr class="sys-divider" />
 
-    <!-- Max. Minusstunden -->
+    <!-- E-Mail-Benachrichtigungen -->
     <div class="sys-section">
-      <h3 class="sys-title">Max. Minusstunden</h3>
-      {#if maxNegError}
+      <h3 class="sys-title">E-Mail-Benachrichtigungen</h3>
+      {#if emailError}
         <div class="alert alert-error" role="alert" style="margin-bottom:1rem;">
-          <span>⚠</span><span>{maxNegError}</span>
+          <span>⚠</span><span>{emailError}</span>
         </div>
       {/if}
       <div class="toggle-row">
         <div class="toggle-info">
-          <span class="toggle-row-label">Limit für negatives Überstundensaldo</span>
+          <span class="toggle-row-label">E-Mail-Benachrichtigungen aktivieren</span>
           <p class="form-hint text-muted">
-            Begrenzt, wie viele Minusstunden Mitarbeiter ansammeln dürfen.
+            Sendet zusätzlich zur In-App-Benachrichtigung eine E-Mail. SMTP muss konfiguriert sein.
           </p>
         </div>
         <label class="switch">
-          <input type="checkbox" bind:checked={maxNegEnabled} />
+          <input type="checkbox" bind:checked={emailEnabled} />
           <span class="switch-slider"></span>
         </label>
       </div>
-      {#if maxNegEnabled}
-        <div class="settings-grid" style="margin-top:0.75rem">
-          <div class="form-group">
-            <label class="form-label" for="max-neg-hours">Max. Minusstunden (h)</label>
-            <input id="max-neg-hours" type="number" min="1" max="999" step="0.5" bind:value={maxNegHours} class="form-input" />
-            <p class="form-hint text-muted">Pro Mitarbeiter individuell überschreibbar.</p>
-          </div>
+      {#if emailEnabled}
+        <h4 class="sys-subtitle" style="margin-top:1rem">Benachrichtigungstypen</h4>
+        <div class="toggle-row">
+          <span class="toggle-row-label">Neuer Urlaubsantrag</span>
+          <label class="switch"><input type="checkbox" bind:checked={emailOnLeaveRequest} /><span class="switch-slider"></span></label>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-row-label">Urlaub genehmigt / abgelehnt</span>
+          <label class="switch"><input type="checkbox" bind:checked={emailOnLeaveDecision} /><span class="switch-slider"></span></label>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-row-label">Überstunden-Warnung</span>
+          <label class="switch"><input type="checkbox" bind:checked={emailOnOvertimeWarning} /><span class="switch-slider"></span></label>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-row-label">Fehlende Zeiteinträge</span>
+          <label class="switch"><input type="checkbox" bind:checked={emailOnMissingEntries} /><span class="switch-slider"></span></label>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-row-label">Vergessene Stempelung</span>
+          <label class="switch"><input type="checkbox" bind:checked={emailOnClockOutReminder} /><span class="switch-slider"></span></label>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-row-label">Monatsabschluss</span>
+          <label class="switch"><input type="checkbox" bind:checked={emailOnMonthClose} /><span class="switch-slider"></span></label>
         </div>
       {/if}
       <div class="settings-actions">
-        <button class="btn btn-primary" onclick={saveMaxNegative} disabled={maxNegSaving}>
-          {maxNegSaving ? "Speichern…" : "Speichern"}
+        <button class="btn btn-primary" onclick={saveEmailConfig} disabled={emailSaving}>
+          {emailSaving ? "Speichern…" : "Speichern"}
         </button>
-        {#if maxNegSaved}
-          <span class="saved-hint">✓ Gespeichert</span>
-        {/if}
-      </div>
-    </div>
-
-    <hr class="sys-divider" />
-
-    <!-- Abwesenheits-Konfiguration -->
-    <div class="sys-section">
-      <h3 class="sys-title">Abwesenheiten & Urlaub</h3>
-      {#if leaveConfigError}
-        <div class="alert alert-error" role="alert" style="margin-bottom:1rem;">
-          <span>⚠</span><span>{leaveConfigError}</span>
-        </div>
-      {/if}
-
-      <h4 class="sys-subtitle">Heiligabend & Silvester</h4>
-      <div class="settings-grid">
-        <div class="form-group">
-          <label class="form-label" for="christmas-rule">Heiligabend (24.12.)</label>
-          <select id="christmas-rule" bind:value={christmasEveRule} class="form-input">
-            <option value="NORMAL">Normaler Arbeitstag</option>
-            <option value="HALF_DAY">Halber Tag frei</option>
-            <option value="FULL_DAY_OFF">Ganzer Tag frei</option>
-          </select>
-        </div>
-        <div class="form-group">
-          <label class="form-label" for="newyears-rule">Silvester (31.12.)</label>
-          <select id="newyears-rule" bind:value={newYearsEveRule} class="form-input">
-            <option value="NORMAL">Normaler Arbeitstag</option>
-            <option value="HALF_DAY">Halber Tag frei</option>
-            <option value="FULL_DAY_OFF">Ganzer Tag frei</option>
-          </select>
-        </div>
-      </div>
-
-      <h4 class="sys-subtitle" style="margin-top:1.5rem">Urlaubsanträge</h4>
-      <div class="settings-grid">
-        <div class="form-group">
-          <label class="form-label" for="lead-time">Vorlaufzeit (Tage)</label>
-          <input id="lead-time" type="number" min="0" max="365" bind:value={vacationLeadTimeDays} class="form-input" />
-          <p class="form-hint text-muted">0 = keine Vorlaufzeit. Gilt nicht für Krankmeldungen.</p>
-        </div>
-        <div class="form-group">
-          <label class="form-label" for="max-advance">Max. Vorausbuchung (Monate)</label>
-          <input id="max-advance" type="number" min="0" max="24" bind:value={vacationMaxAdvanceMonths} class="form-input" />
-          <p class="form-hint text-muted">0 = unbegrenzt. z. B. 12 = max. 1 Jahr im Voraus.</p>
-        </div>
-      </div>
-      <div class="toggle-row" style="margin-top:0.75rem">
-        <div class="toggle-info">
-          <span class="toggle-row-label">Halbe Tage erlauben</span>
-          <p class="form-hint text-muted">Mitarbeiter können halbe Urlaubstage beantragen.</p>
-        </div>
-        <label class="switch">
-          <input type="checkbox" bind:checked={halfDayAllowed} />
-          <span class="switch-slider"></span>
-        </label>
-      </div>
-
-      <h4 class="sys-subtitle" style="margin-top:1.5rem">Krankmeldungen</h4>
-      <div class="toggle-row">
-        <div class="toggle-info">
-          <span class="toggle-row-label">Selbsteintragen erlauben</span>
-          <p class="form-hint text-muted">Mitarbeiter können Krankmeldungen selbst erstellen.</p>
-        </div>
-        <label class="switch">
-          <input type="checkbox" bind:checked={sickSelfReport} />
-          <span class="switch-slider"></span>
-        </label>
-      </div>
-      <div class="settings-grid" style="margin-top:0.75rem">
-        <div class="form-group">
-          <label class="form-label" for="sick-note-days">AU-Pflicht nach (Tage)</label>
-          <input id="sick-note-days" type="number" min="1" max="30" bind:value={sickNoteRequiredAfterDays} class="form-input" />
-          <p class="form-hint text-muted">Ab dem X. Krankheitstag wird eine AU-Bescheinigung angefordert (§ 5 EFZG).</p>
-        </div>
-      </div>
-
-      <h4 class="sys-subtitle" style="margin-top:1.5rem">Teilzeit-Urlaub</h4>
-      <div class="toggle-row">
-        <div class="toggle-info">
-          <span class="toggle-row-label">Automatische Pro-Rata-Berechnung</span>
-          <p class="form-hint text-muted">Urlaubsanspruch wird automatisch anhand der Arbeitstage/Woche berechnet.</p>
-        </div>
-        <label class="switch">
-          <input type="checkbox" bind:checked={autoCalcPartTimeVacation} />
-          <span class="switch-slider"></span>
-        </label>
-      </div>
-      {#if autoCalcPartTimeVacation}
-        <div class="settings-grid" style="margin-top:0.75rem">
-          <div class="form-group">
-            <label class="form-label" for="ft-days">Vollzeit-Arbeitstage/Woche</label>
-            <select id="ft-days" bind:value={fullTimeWorkDaysPerWeek} class="form-input">
-              <option value={5}>5 Tage (Mo–Fr)</option>
-              <option value={6}>6 Tage (Mo–Sa)</option>
-            </select>
-            <p class="form-hint text-muted">Referenz für die Pro-Rata-Berechnung (BUrlG).</p>
-          </div>
-        </div>
-      {/if}
-
-      <div class="settings-actions">
-        <button class="btn btn-primary" onclick={saveLeaveConfig} disabled={leaveConfigSaving}>
-          {leaveConfigSaving ? "Speichern…" : "Speichern"}
-        </button>
-        {#if leaveConfigSaved}
+        {#if emailSaved}
           <span class="saved-hint">✓ Gespeichert</span>
         {/if}
       </div>

--- a/apps/web/src/routes/(app)/admin/vacation/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/vacation/+page.svelte
@@ -102,6 +102,20 @@
   let gMissingDays = $state(7);
   let gAutoDeleteHours = $state(14);
 
+  // Abwesenheits-Konfiguration
+  let christmasEveRule = $state("NORMAL");
+  let newYearsEveRule = $state("NORMAL");
+  let vacationLeadTimeDays = $state(0);
+  let vacationMaxAdvanceMonths = $state(0);
+  let halfDayAllowed = $state(true);
+  let sickSelfReport = $state(true);
+  let sickNoteRequiredAfterDays = $state(3);
+  let autoCalcPartTimeVacation = $state(true);
+  let fullTimeWorkDaysPerWeek = $state(5);
+  // Max Minusstunden
+  let maxNegEnabled = $state(false);
+  let maxNegHours = $state(20);
+
   let gMaxDay = $derived(MONTH_MAX_DAYS[gCarryOverMonth - 1] ?? 31);
   run(() => {
     gCarryOverDay = gMaxDay;
@@ -163,6 +177,19 @@
       gMissingDays = cfg.missingEntriesDays ?? 7;
       gAutoDeleteHours = cfg.autoDeleteOpenHours ?? 14;
 
+      // Leave/overtime config
+      christmasEveRule = (cfg as any).christmasEveRule ?? "NORMAL";
+      newYearsEveRule = (cfg as any).newYearsEveRule ?? "NORMAL";
+      vacationLeadTimeDays = (cfg as any).vacationLeadTimeDays ?? 0;
+      vacationMaxAdvanceMonths = (cfg as any).vacationMaxAdvanceMonths ?? 0;
+      halfDayAllowed = (cfg as any).halfDayAllowed ?? true;
+      sickSelfReport = (cfg as any).sickSelfReport ?? true;
+      sickNoteRequiredAfterDays = (cfg as any).sickNoteRequiredAfterDays ?? 3;
+      autoCalcPartTimeVacation = (cfg as any).autoCalcPartTimeVacation ?? true;
+      fullTimeWorkDaysPerWeek = (cfg as any).fullTimeWorkDaysPerWeek ?? 5;
+      const maxNegMinutes = (cfg as any).maxNegativeBalanceMinutes;
+      if (maxNegMinutes != null) { maxNegEnabled = true; maxNegHours = maxNegMinutes / 60; }
+
       employees = await api.get<EmployeeRow[]>("/settings/employees");
     } catch (e: unknown) {
       error = e instanceof Error ? e.message : "Fehler beim Laden";
@@ -197,6 +224,19 @@
         clockOutReminderHours: gClockOutHours,
         missingEntriesDays: gMissingDays,
         autoDeleteOpenHours: gAutoDeleteHours,
+        christmasEveRule,
+        newYearsEveRule,
+        vacationLeadTimeDays,
+        vacationMaxAdvanceMonths,
+        halfDayAllowed,
+        sickSelfReport,
+        sickNoteRequiredAfterDays,
+        autoCalcPartTimeVacation,
+        fullTimeWorkDaysPerWeek,
+      });
+      // Save max negative via security endpoint
+      await api.put("/settings/security", {
+        maxNegativeBalanceMinutes: maxNegEnabled ? Math.round(maxNegHours * 60) : null,
       });
       // Reset nach Speichern
       gApplyToExisting = false;
@@ -618,6 +658,101 @@
           </p>
         </div>
       </div>
+    </div>
+  </div>
+
+  <!-- Card 5: Abwesenheiten & Sonderregelungen -->
+  <div class="section-group">
+    <div class="settings-section">
+      <h3 class="section-title">Heiligabend & Silvester</h3>
+      <div class="inline-settings">
+        <div class="form-group">
+          <label class="form-label" for="christmas-rule">Heiligabend (24.12.)</label>
+          <select id="christmas-rule" bind:value={christmasEveRule} class="form-input">
+            <option value="NORMAL">Normaler Arbeitstag</option>
+            <option value="HALF_DAY">Halber Tag frei</option>
+            <option value="FULL_DAY_OFF">Ganzer Tag frei</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="newyears-rule">Silvester (31.12.)</label>
+          <select id="newyears-rule" bind:value={newYearsEveRule} class="form-input">
+            <option value="NORMAL">Normaler Arbeitstag</option>
+            <option value="HALF_DAY">Halber Tag frei</option>
+            <option value="FULL_DAY_OFF">Ganzer Tag frei</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <div class="settings-section">
+      <h3 class="section-title">Urlaubsanträge</h3>
+      <div class="inline-settings">
+        <div class="form-group">
+          <label class="form-label" for="lead-time">Vorlaufzeit (Tage)</label>
+          <input id="lead-time" type="number" min="0" max="365" bind:value={vacationLeadTimeDays} class="form-input" />
+          <p class="form-hint text-muted">0 = keine Vorlaufzeit. Gilt nicht für Krankmeldungen.</p>
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="max-advance">Max. Vorausbuchung (Monate)</label>
+          <input id="max-advance" type="number" min="0" max="24" bind:value={vacationMaxAdvanceMonths} class="form-input" />
+          <p class="form-hint text-muted">0 = unbegrenzt.</p>
+        </div>
+      </div>
+      <label class="form-label toggle-label" style="margin-top:0.75rem">
+        <input type="checkbox" bind:checked={halfDayAllowed} />
+        Halbe Tage erlauben
+      </label>
+    </div>
+
+    <div class="settings-section">
+      <h3 class="section-title">Krankmeldungen</h3>
+      <label class="form-label toggle-label">
+        <input type="checkbox" bind:checked={sickSelfReport} />
+        Mitarbeiter dürfen Krankmeldung selbst eintragen
+      </label>
+      <div class="inline-settings" style="margin-top:0.75rem">
+        <div class="form-group">
+          <label class="form-label" for="sick-note-days">AU-Pflicht nach (Tagen)</label>
+          <input id="sick-note-days" type="number" min="1" max="30" bind:value={sickNoteRequiredAfterDays} class="form-input" />
+          <p class="form-hint text-muted">§ 5 EFZG — Standard: 3 Tage.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="settings-section">
+      <h3 class="section-title">Teilzeit-Urlaub</h3>
+      <label class="form-label toggle-label">
+        <input type="checkbox" bind:checked={autoCalcPartTimeVacation} />
+        Automatische Pro-Rata-Berechnung (BUrlG)
+      </label>
+      {#if autoCalcPartTimeVacation}
+        <div class="inline-settings" style="margin-top:0.75rem">
+          <div class="form-group">
+            <label class="form-label" for="ft-days">Vollzeit-Arbeitstage/Woche</label>
+            <select id="ft-days" bind:value={fullTimeWorkDaysPerWeek} class="form-input">
+              <option value={5}>5 Tage (Mo–Fr)</option>
+              <option value={6}>6 Tage (Mo–Sa)</option>
+            </select>
+          </div>
+        </div>
+      {/if}
+    </div>
+
+    <div class="settings-section">
+      <h3 class="section-title">Max. Minusstunden</h3>
+      <label class="form-label toggle-label">
+        <input type="checkbox" bind:checked={maxNegEnabled} />
+        Limit für negatives Überstundensaldo
+      </label>
+      {#if maxNegEnabled}
+        <div class="inline-settings" style="margin-top:0.75rem">
+          <div class="form-group">
+            <label class="form-label" for="max-neg-hours">Max. Minusstunden (h)</label>
+            <input id="max-neg-hours" type="number" min="1" max="999" step="0.5" bind:value={maxNegHours} class="form-input" />
+          </div>
+        </div>
+      {/if}
     </div>
   </div>
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -94,6 +94,14 @@ model TenantConfig {
   autoCalcPartTimeVacation Boolean @default(true) // Automatische Pro-Rata Berechnung
   fullTimeWorkDaysPerWeek  Int    @default(5)     // Referenz für Vollzeit (5 oder 6)
 
+  // E-Mail-Benachrichtigungen
+  emailNotificationsEnabled  Boolean @default(false) // Master switch
+  emailOnLeaveRequest        Boolean @default(true)  // Neuer Urlaubsantrag
+  emailOnLeaveDecision       Boolean @default(true)  // Urlaub genehmigt/abgelehnt
+  emailOnOvertimeWarning     Boolean @default(false) // Überstunden-Schwellwert
+  emailOnMissingEntries      Boolean @default(false) // Fehlende Zeiteinträge
+  emailOnClockOutReminder    Boolean @default(false) // Vergessene Stempelung
+  emailOnMonthClose          Boolean @default(true)  // Monatsabschluss
   // Benachrichtigungen
   clockOutReminderHours  Int @default(10)  // Stunden nach denen an offene Stempelung erinnert wird
   missingEntriesDays     Int @default(7)   // Tage ohne Einträge bevor erinnert wird
@@ -123,8 +131,9 @@ model User {
   email        String     @unique
   passwordHash String
   role         Role       @default(EMPLOYEE)
-  isActive     Boolean    @default(true)
-  lastLoginAt  DateTime?  @db.Timestamptz
+  isActive           Boolean    @default(true)
+  emailNotifications Boolean    @default(true) // Per-user email opt-out
+  lastLoginAt        DateTime?  @db.Timestamptz
   createdAt    DateTime   @default(now()) @db.Timestamptz
   updatedAt    DateTime   @updatedAt      @db.Timestamptz
 


### PR DESCRIPTION
## Summary
- Configurable email notifications per type with master switch and per-user opt-out
- Moved Max Minusstunden + Abwesenheits-Config from System to Urlaub & Zeiten tab

Closes #26

## Test plan
- [ ] Admin > System: E-Mail-Benachrichtigungen section with toggles
- [ ] Admin > Urlaub & Zeiten: Heiligabend, Urlaubsanträge, Krankmeldungen, Teilzeit, Minusstunden sections
- [ ] Enable email notifications + submit leave request → email sent to managers
- [ ] Approve leave → email sent to employee

🤖 Generated with [Claude Code](https://claude.com/claude-code)