### PR TITLE
feat: automatic reminders for pending leave + upcoming absences

### DIFF
--- a/apps/api/src/plugins/attendance-checker.ts
+++ b/apps/api/src/plugins/attendance-checker.ts
@@ -307,6 +307,119 @@ export const attendanceCheckerPlugin = fp(async (app) => {
     }
   }
 
+  /**
+   * Feature 4: Pending leave request reminder — runs daily at 09:00.
+   * Reminds managers about leave requests that have been PENDING for too long.
+   */
+  async function checkPendingLeaveRequests() {
+    app.log.info("Reminder: Prüfe offene Urlaubsanträge");
+    try {
+      const tenants = await app.prisma.tenant.findMany({ select: { id: true } });
+      for (const tenant of tenants) {
+        const cfg = await app.prisma.tenantConfig.findUnique({ where: { tenantId: tenant.id } });
+        if (!cfg?.reminderPendingLeaveEnabled) continue;
+
+        const thresholdHours = cfg.reminderPendingLeaveHours ?? 48;
+        const cutoff = new Date(Date.now() - thresholdHours * 60 * 60 * 1000);
+
+        const pendingRequests = await app.prisma.leaveRequest.findMany({
+          where: {
+            deletedAt: null,
+            status: "PENDING",
+            createdAt: { lt: cutoff },
+            employee: { tenantId: tenant.id },
+          },
+          include: {
+            employee: { select: { firstName: true, lastName: true } },
+            leaveType: { select: { name: true } },
+          },
+        });
+
+        if (pendingRequests.length === 0) continue;
+
+        const managers = await app.prisma.user.findMany({
+          where: { role: { in: ["ADMIN", "MANAGER"] }, isActive: true, employee: { tenantId: tenant.id } },
+          select: { id: true },
+        });
+
+        for (const req of pendingRequests) {
+          for (const mgr of managers) {
+            const existing = await app.prisma.notification.findFirst({
+              where: { userId: mgr.id, type: "PENDING_LEAVE_REMINDER", link: `/leave?request=${req.id}` },
+            });
+            if (existing) continue;
+
+            await app.notify({
+              userId: mgr.id,
+              type: "PENDING_LEAVE_REMINDER",
+              title: "Offener Urlaubsantrag",
+              message: `${req.employee.firstName} ${req.employee.lastName}: ${req.leaveType.name} wartet seit über ${thresholdHours}h auf Genehmigung.`,
+              link: `/leave?request=${req.id}`,
+              tenantId: tenant.id,
+            });
+          }
+        }
+      }
+    } catch (err) {
+      app.log.error({ err }, "Reminder: Fehler bei offenen Urlaubsanträgen");
+    }
+  }
+
+  /**
+   * Feature 5: Upcoming absence reminder — runs daily at 09:00.
+   * Reminds employees about their approved absences starting soon.
+   */
+  async function checkUpcomingAbsences() {
+    app.log.info("Reminder: Prüfe bevorstehende Abwesenheiten");
+    try {
+      const tenants = await app.prisma.tenant.findMany({ select: { id: true } });
+      for (const tenant of tenants) {
+        const cfg = await app.prisma.tenantConfig.findUnique({ where: { tenantId: tenant.id } });
+        if (!cfg?.reminderUpcomingAbsenceEnabled) continue;
+
+        const daysAhead = cfg.reminderUpcomingAbsenceDays ?? 3;
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const targetDate = new Date(today);
+        targetDate.setDate(targetDate.getDate() + daysAhead);
+
+        const upcoming = await app.prisma.leaveRequest.findMany({
+          where: {
+            deletedAt: null,
+            status: "APPROVED",
+            startDate: { gte: today, lte: targetDate },
+            employee: { tenantId: tenant.id },
+          },
+          include: {
+            employee: { select: { userId: true, firstName: true } },
+            leaveType: { select: { name: true } },
+          },
+        });
+
+        for (const req of upcoming) {
+          const startStr = req.startDate.toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit" });
+          const dedupLink = `/leave?request=${req.id}&reminder=upcoming`;
+
+          const existing = await app.prisma.notification.findFirst({
+            where: { userId: req.employee.userId, type: "UPCOMING_ABSENCE", link: dedupLink },
+          });
+          if (existing) continue;
+
+          await app.notify({
+            userId: req.employee.userId,
+            type: "UPCOMING_ABSENCE",
+            title: "Bevorstehende Abwesenheit",
+            message: `Dein ${req.leaveType.name} beginnt am ${startStr}.`,
+            link: dedupLink,
+            tenantId: tenant.id,
+          });
+        }
+      }
+    } catch (err) {
+      app.log.error({ err }, "Reminder: Fehler bei bevorstehenden Abwesenheiten");
+    }
+  }
+
   app.addHook("onReady", async () => {
     try {
       // Clock-out check: every hour at minute 0
@@ -335,6 +448,24 @@ export const attendanceCheckerPlugin = fp(async (app) => {
       });
       tasks.push(missingTask);
       app.log.info("Attendance-Checker: Fehlende-Einträge Erinnerung geplant (täglich 09:00)");
+
+      // Pending leave requests: daily at 09:15
+      const pendingLeaveTask = cron.schedule("15 9 * * *", () => {
+        checkPendingLeaveRequests().catch((err) =>
+          app.log.error({ err }, "Reminder: Offene-Anträge Job fehlgeschlagen"),
+        );
+      });
+      tasks.push(pendingLeaveTask);
+      app.log.info("Reminder: Offene Urlaubsanträge geplant (täglich 09:15)");
+
+      // Upcoming absences: daily at 08:00
+      const upcomingTask = cron.schedule("0 8 * * *", () => {
+        checkUpcomingAbsences().catch((err) =>
+          app.log.error({ err }, "Reminder: Bevorstehende-Abwesenheiten Job fehlgeschlagen"),
+        );
+      });
+      tasks.push(upcomingTask);
+      app.log.info("Reminder: Bevorstehende Abwesenheiten geplant (täglich 08:00)");
     } catch (err) {
       app.log.error({ err }, "Attendance-Checker konnte nicht gestartet werden");
     }

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -49,6 +49,11 @@ const tenantConfigSchema = z.object({
   // Part-time vacation
   autoCalcPartTimeVacation: z.boolean().optional(),
   fullTimeWorkDaysPerWeek: z.number().int().min(1).max(7).optional(),
+  // Reminders
+  reminderPendingLeaveHours: z.number().int().min(1).max(720).optional(),
+  reminderUpcomingAbsenceDays: z.number().int().min(1).max(30).optional(),
+  reminderPendingLeaveEnabled: z.boolean().optional(),
+  reminderUpcomingAbsenceEnabled: z.boolean().optional(),
 });
 
 const vacationEntitlementSchema = z.object({
@@ -125,6 +130,10 @@ export async function settingsRoutes(app: FastifyInstance) {
         sickNoteRequiredAfterDays: 3,
         autoCalcPartTimeVacation: true,
         fullTimeWorkDaysPerWeek: 5,
+        reminderPendingLeaveHours: 48,
+        reminderUpcomingAbsenceDays: 3,
+        reminderPendingLeaveEnabled: true,
+        reminderUpcomingAbsenceEnabled: true,
       };
 
       return { ...base, federalState: tenant?.federalState ?? "NIEDERSACHSEN" };

--- a/apps/web/src/routes/(app)/admin/vacation/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/vacation/+page.svelte
@@ -115,6 +115,11 @@
   // Max Minusstunden
   let maxNegEnabled = $state(false);
   let maxNegHours = $state(20);
+  // Erinnerungen
+  let reminderPendingEnabled = $state(true);
+  let reminderPendingHours = $state(48);
+  let reminderUpcomingEnabled = $state(true);
+  let reminderUpcomingDays = $state(3);
 
   let gMaxDay = $derived(MONTH_MAX_DAYS[gCarryOverMonth - 1] ?? 31);
   run(() => {
@@ -189,6 +194,10 @@
       fullTimeWorkDaysPerWeek = (cfg as any).fullTimeWorkDaysPerWeek ?? 5;
       const maxNegMinutes = (cfg as any).maxNegativeBalanceMinutes;
       if (maxNegMinutes != null) { maxNegEnabled = true; maxNegHours = maxNegMinutes / 60; }
+      reminderPendingEnabled = (cfg as any).reminderPendingLeaveEnabled ?? true;
+      reminderPendingHours = (cfg as any).reminderPendingLeaveHours ?? 48;
+      reminderUpcomingEnabled = (cfg as any).reminderUpcomingAbsenceEnabled ?? true;
+      reminderUpcomingDays = (cfg as any).reminderUpcomingAbsenceDays ?? 3;
 
       employees = await api.get<EmployeeRow[]>("/settings/employees");
     } catch (e: unknown) {
@@ -233,6 +242,10 @@
         sickNoteRequiredAfterDays,
         autoCalcPartTimeVacation,
         fullTimeWorkDaysPerWeek,
+        reminderPendingLeaveHours: reminderPendingHours,
+        reminderUpcomingAbsenceDays: reminderUpcomingDays,
+        reminderPendingLeaveEnabled: reminderPendingEnabled,
+        reminderUpcomingAbsenceEnabled: reminderUpcomingEnabled,
       });
       // Save max negative via security endpoint
       await api.put("/settings/security", {
@@ -750,6 +763,33 @@
           <div class="form-group">
             <label class="form-label" for="max-neg-hours">Max. Minusstunden (h)</label>
             <input id="max-neg-hours" type="number" min="1" max="999" step="0.5" bind:value={maxNegHours} class="form-input" />
+          </div>
+        </div>
+      {/if}
+    </div>
+    <div class="settings-section">
+      <h3 class="section-title">Automatische Erinnerungen</h3>
+      <label class="form-label toggle-label">
+        <input type="checkbox" bind:checked={reminderPendingEnabled} />
+        Offene Urlaubsanträge — Manager erinnern
+      </label>
+      {#if reminderPendingEnabled}
+        <div class="inline-settings" style="margin-top:0.5rem">
+          <div class="form-group">
+            <label class="form-label" for="rem-pending-h">Nach (Stunden)</label>
+            <input id="rem-pending-h" type="number" min="1" max="720" bind:value={reminderPendingHours} class="form-input" />
+          </div>
+        </div>
+      {/if}
+      <label class="form-label toggle-label" style="margin-top:0.75rem">
+        <input type="checkbox" bind:checked={reminderUpcomingEnabled} />
+        Bevorstehende Abwesenheiten — Mitarbeiter erinnern
+      </label>
+      {#if reminderUpcomingEnabled}
+        <div class="inline-settings" style="margin-top:0.5rem">
+          <div class="form-group">
+            <label class="form-label" for="rem-upcoming-d">Tage vorher</label>
+            <input id="rem-upcoming-d" type="number" min="1" max="30" bind:value={reminderUpcomingDays} class="form-input" />
           </div>
         </div>
       {/if}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -102,6 +102,11 @@ model TenantConfig {
   emailOnMissingEntries      Boolean @default(false) // Fehlende Zeiteinträge
   emailOnClockOutReminder    Boolean @default(false) // Vergessene Stempelung
   emailOnMonthClose          Boolean @default(true)  // Monatsabschluss
+  // Automatische Erinnerungen
+  reminderPendingLeaveHours    Int     @default(48)   // Manager erinnern nach X Stunden ohne Reaktion
+  reminderUpcomingAbsenceDays  Int     @default(3)    // MA erinnern X Tage vor Abwesenheit
+  reminderPendingLeaveEnabled  Boolean @default(true)
+  reminderUpcomingAbsenceEnabled Boolean @default(true)
   // Benachrichtigungen
   clockOutReminderHours  Int @default(10)  // Stunden nach denen an offene Stempelung erinnert wird
   missingEntriesDays     Int @default(7)   // Tage ohne Einträge bevor erinnert wird


### PR DESCRIPTION
## Summary
- Pending leave reminder: cron notifies managers about unreviewed leave requests (>48h)
- Upcoming absence reminder: cron notifies employees X days before approved absence
- Configurable thresholds + enable/disable per reminder type

Closes #47

## Test plan
- [ ] Admin > Urlaub & Zeiten: Automatische Erinnerungen section visible
- [ ] Toggle + threshold config saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)