### PR TITLE
feat: generic API keys with scopes for external integrations

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -36,6 +36,7 @@ import { importRoutes } from "./routes/imports";
 import { terminalRoutes } from "./routes/terminals";
 import { specialLeaveRoutes } from "./routes/special-leave";
 import { avatarRoutes } from "./routes/avatars";
+import { apiKeyRoutes } from "./routes/api-keys";
 
 export async function buildApp() {
   // ── Logger configuration ──────────────────────────────────
@@ -209,6 +210,7 @@ export async function buildApp() {
   await app.register(terminalRoutes, { prefix: "/api/v1/terminals" });
   await app.register(specialLeaveRoutes, { prefix: "/api/v1/special-leave" });
   await app.register(avatarRoutes, { prefix: "/api/v1/avatars" });
+  await app.register(apiKeyRoutes, { prefix: "/api/v1/api-keys" });
 
   // ── Health ────────────────────────────────────────────────
   app.get("/health", async () => ({ status: "ok", timestamp: new Date().toISOString() }));

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,4 +1,5 @@
 import { FastifyRequest, FastifyReply } from "fastify";
+import { createHash } from "crypto";
 import { Role } from "@clokr/db";
 
 export interface JwtPayload {
@@ -15,7 +16,44 @@ declare module "@fastify/jwt" {
   }
 }
 
+/**
+ * Authenticate via JWT or API Key (clk_ prefix).
+ * API keys are validated against the database and scopes are attached to the request.
+ */
 export async function requireAuth(req: FastifyRequest, reply: FastifyReply) {
+  const authHeader = req.headers.authorization;
+
+  // Check for API key (clk_ prefix)
+  if (authHeader?.startsWith("Bearer clk_")) {
+    const rawKey = authHeader.slice(7);
+    const keyHash = createHash("sha256").update(rawKey).digest("hex");
+
+    const apiKey = await req.server.prisma.apiKey.findUnique({ where: { keyHash } });
+    if (!apiKey || apiKey.revokedAt) {
+      return reply.code(401).send({ error: "Ungültiger oder widerrufener API Key" });
+    }
+    if (apiKey.expiresAt && apiKey.expiresAt < new Date()) {
+      return reply.code(401).send({ error: "API Key abgelaufen" });
+    }
+
+    // Update lastUsedAt (fire and forget)
+    req.server.prisma.apiKey
+      .update({ where: { id: apiKey.id }, data: { lastUsedAt: new Date() } })
+      .catch(() => {});
+
+    // Set user context from API key (role = ADMIN for admin scope, MANAGER otherwise)
+    const isAdmin = apiKey.scopes.includes("admin");
+    req.user = {
+      sub: `apikey:${apiKey.id}`,
+      role: isAdmin ? "ADMIN" : ("MANAGER" as Role),
+      tenantId: apiKey.tenantId,
+    };
+    // Attach scopes for downstream checks
+    (req as any).apiKeyScopes = apiKey.scopes;
+    return;
+  }
+
+  // Standard JWT auth
   try {
     await req.jwtVerify();
   } catch {
@@ -26,6 +64,7 @@ export async function requireAuth(req: FastifyRequest, reply: FastifyReply) {
 export function requireRole(...roles: Role[]) {
   return async (req: FastifyRequest, reply: FastifyReply) => {
     await requireAuth(req, reply);
+    if (reply.sent) return; // Auth already failed
     if (!roles.includes(req.user.role)) {
       return reply.code(403).send({ error: "Forbidden" });
     }

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -1,0 +1,141 @@
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import crypto, { createHash } from "crypto";
+import { requireRole } from "../middleware/auth";
+
+const VALID_SCOPES = [
+  "read:employees",
+  "write:employees",
+  "read:time-entries",
+  "write:time-entries",
+  "read:leave",
+  "write:leave",
+  "read:reports",
+  "read:overtime",
+  "admin",
+] as const;
+
+const createKeySchema = z.object({
+  name: z.string().min(1).max(100),
+  scopes: z.array(z.enum(VALID_SCOPES)).min(1),
+  expiresAt: z.string().datetime().nullable().optional(),
+});
+
+export async function apiKeyRoutes(app: FastifyInstance) {
+  // GET /api/v1/api-keys — list all keys for tenant
+  app.get("/", {
+    schema: { tags: ["API Keys"], security: [{ bearerAuth: [] }] },
+    preHandler: requireRole("ADMIN"),
+    handler: async (req) => {
+      const keys = await app.prisma.apiKey.findMany({
+        where: { tenantId: req.user.tenantId },
+        orderBy: { createdAt: "desc" },
+        select: {
+          id: true,
+          name: true,
+          keyPrefix: true,
+          scopes: true,
+          expiresAt: true,
+          lastUsedAt: true,
+          revokedAt: true,
+          createdBy: true,
+          createdAt: true,
+        },
+      });
+      return keys;
+    },
+  });
+
+  // POST /api/v1/api-keys — create a new API key
+  app.post("/", {
+    schema: { tags: ["API Keys"], security: [{ bearerAuth: [] }] },
+    preHandler: requireRole("ADMIN"),
+    handler: async (req) => {
+      const body = createKeySchema.parse(req.body);
+      const tenantId = req.user.tenantId;
+
+      // Generate key: clk_ prefix + 40 random hex chars
+      const rawKey = `clk_${crypto.randomBytes(20).toString("hex")}`;
+      const keyHash = createHash("sha256").update(rawKey).digest("hex");
+      const keyPrefix = rawKey.slice(0, 12); // "clk_abcd1234"
+
+      const apiKey = await app.prisma.apiKey.create({
+        data: {
+          tenantId,
+          name: body.name,
+          keyHash,
+          keyPrefix,
+          scopes: body.scopes,
+          expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+          createdBy: req.user.sub,
+        },
+      });
+
+      await app.audit({
+        userId: req.user.sub,
+        action: "CREATE",
+        entity: "ApiKey",
+        entityId: apiKey.id,
+        newValue: { name: body.name, scopes: body.scopes, keyPrefix },
+        request: { ip: req.ip, headers: req.headers as Record<string, string> },
+      });
+
+      // Return raw key ONCE — it cannot be retrieved later
+      return { ...apiKey, rawKey };
+    },
+  });
+
+  // DELETE /api/v1/api-keys/:id — revoke a key
+  app.delete("/:id", {
+    schema: { tags: ["API Keys"], security: [{ bearerAuth: [] }] },
+    preHandler: requireRole("ADMIN"),
+    handler: async (req, reply) => {
+      const { id } = req.params as { id: string };
+
+      const key = await app.prisma.apiKey.findUnique({ where: { id } });
+      if (!key || key.tenantId !== req.user.tenantId) {
+        return reply.code(404).send({ error: "API Key nicht gefunden" });
+      }
+
+      await app.prisma.apiKey.update({
+        where: { id },
+        data: { revokedAt: new Date() },
+      });
+
+      await app.audit({
+        userId: req.user.sub,
+        action: "DELETE",
+        entity: "ApiKey",
+        entityId: id,
+        oldValue: { name: key.name, keyPrefix: key.keyPrefix },
+        request: { ip: req.ip, headers: req.headers as Record<string, string> },
+      });
+
+      return { success: true };
+    },
+  });
+
+  // GET /api/v1/api-keys/scopes — list available scopes
+  app.get("/scopes", {
+    schema: { tags: ["API Keys"], security: [{ bearerAuth: [] }] },
+    preHandler: requireRole("ADMIN"),
+    handler: async () => {
+      return VALID_SCOPES.map((s) => ({ scope: s, description: scopeDescription(s) }));
+    },
+  });
+}
+
+function scopeDescription(scope: string): string {
+  const map: Record<string, string> = {
+    "read:employees": "Mitarbeiterdaten lesen",
+    "write:employees": "Mitarbeiterdaten bearbeiten",
+    "read:time-entries": "Zeiteinträge lesen",
+    "write:time-entries": "Zeiteinträge erstellen/bearbeiten",
+    "read:leave": "Abwesenheiten lesen",
+    "write:leave": "Abwesenheiten erstellen",
+    "read:reports": "Berichte/Exporte lesen",
+    "read:overtime": "Überstundenkonto lesen",
+    admin: "Voller Zugriff (alle Berechtigungen)",
+  };
+  return map[scope] ?? scope;
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Tenant {
   companyShutdowns  CompanyShutdown[]
   shiftTemplates    ShiftTemplate[]
   terminalApiKeys   TerminalApiKey[]
+  apiKeys           ApiKey[]
   specialLeaveRules SpecialLeaveRule[]
 }
 
@@ -549,6 +550,23 @@ model TerminalApiKey {
   lastUsedAt DateTime?
   revokedAt  DateTime?
   createdAt  DateTime  @default(now())
+  tenant     Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  @@index([tenantId])
+}
+
+model ApiKey {
+  id         String    @id @default(uuid())
+  tenantId   String
+  name       String
+  keyHash    String    @unique
+  keyPrefix  String    // e.g. "clk_abc1" (shown in UI)
+  scopes     String[]  // e.g. ["read:employees", "read:time-entries", "read:reports"]
+  expiresAt  DateTime? @db.Timestamptz
+  lastUsedAt DateTime? @db.Timestamptz
+  revokedAt  DateTime? @db.Timestamptz
+  createdBy  String    // userId who created this key
+  createdAt  DateTime  @default(now()) @db.Timestamptz
+
   tenant     Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   @@index([tenantId])
 }


### PR DESCRIPTION
## Summary
- Generic API key system with 9 scopes for external integrations
- Auth middleware supports both JWT and API key (clk_ prefix) authentication
- CRUD endpoints with audit logging

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)