### PR TITLE
fix(docker): copy generated Prisma client into dist/ for compiled seed.js

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -31,6 +31,10 @@ RUN pnpm --filter @clokr/api build
 # Compile seed script for runtime (tsx not available in prod)
 RUN pnpm --filter @clokr/db run seed:build
 
+# Copy generated Prisma client into dist/ so compiled seed.js can resolve
+# '../generated/client' relative to dist/src/seed.js → dist/generated/client
+RUN cp -r /app/packages/db/generated /app/packages/db/dist/generated
+
 # ── Stage 3: Production runtime ────────────────────────────────────────────
 FROM node:24-alpine AS runtime
 RUN apk update && apk upgrade --no-cache && apk add --no-cache su-exec


### PR DESCRIPTION
## Summary

- **Bug**: API container crashes on startup with `Cannot find module '../generated/client'`
- **Root cause**: `dist/src/seed.js` resolves `../generated/client` as `dist/generated/client`, but `prisma generate` outputs to `packages/db/generated/client` — the `dist/` copy never existed
- **Fix**: `cp -r packages/db/generated packages/db/dist/generated` after `seed:build` in the build stage

Closes #119

## Test plan
- [ ] `docker compose up --build` with `SEED_DEMO_DATA=true` — seed completes without `MODULE_NOT_FOUND` error
- [ ] DB gets seeded with demo data on fresh start

🤖 Generated with [Claude Code](https://claude.com/claude-code)