### PR TITLE
fix(security): require auth on GET /avatars/:employeeId — DSGVO

### DIFF
--- a/apps/api/src/routes/avatars.ts
+++ b/apps/api/src/routes/avatars.ts
@@ -62,9 +62,10 @@ export async function avatarRoutes(app: FastifyInstance) {
     },
   });
 
-  // GET /api/v1/avatars/:employeeId — serve avatar (no auth — used in <img> tags)
+  // GET /api/v1/avatars/:employeeId — serve avatar (requires auth — DSGVO Art. 4)
   app.get("/:employeeId", {
-    schema: { tags: ["Avatare"] },
+    schema: { tags: ["Avatare"], security: [{ bearerAuth: [] }] },
+    preHandler: requireAuth,
     handler: async (req, reply) => {
       const { employeeId } = req.params as { employeeId: string };
 
@@ -73,10 +74,15 @@ export async function avatarRoutes(app: FastifyInstance) {
         return reply.code(404).send({ error: "Kein Avatar vorhanden" });
       }
 
+      // Tenant scope: only users in the same tenant may access the avatar
+      if (employee.tenantId !== req.user.tenantId) {
+        return reply.code(403).send({ error: "Keine Berechtigung" });
+      }
+
       try {
         const buffer = await app.storage.getBuffer(employee.avatarPath);
         reply.header("Content-Type", "image/webp");
-        reply.header("Cache-Control", "public, max-age=3600");
+        reply.header("Cache-Control", "private, max-age=3600");
         return reply.send(buffer);
       } catch {
         return reply.code(404).send({ error: "Avatar nicht gefunden" });

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -28,6 +28,30 @@
   let showNotifications = $state(false);
   let pollInterval: ReturnType<typeof setInterval> | undefined;
 
+  // ── Avatar (auth-gated fetch — DSGVO) ──────────────────────────
+  let sidebarAvatarSrc = $state<string | null>(null);
+
+  $effect(() => {
+    const empId = $authStore.user?.employeeId;
+    const token = $authStore.accessToken;
+    if (!empId || !token) return;
+
+    let objectUrl: string | null = null;
+    fetch(`/api/v1/avatars/${empId}`, { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => (r.ok ? r.blob() : null))
+      .then((blob) => {
+        if (blob) {
+          objectUrl = URL.createObjectURL(blob);
+          sidebarAvatarSrc = objectUrl;
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  });
+
   async function loadNotifications() {
     try {
       const res = await api.get<{ notifications: Notification[]; unreadCount: number }>(
@@ -308,17 +332,8 @@
       <div class="sidebar-footer">
         {#if $authStore.user}
           <a href="/settings" class="sidebar-user">
-            {#if $authStore.user.employeeId}
-              <img
-                src="/api/v1/avatars/{$authStore.user.employeeId}"
-                alt=""
-                class="sidebar-user-avatar-img"
-                onerror={(e) => {
-                  (e.target as HTMLImageElement).style.display = "none";
-                  if (e.target instanceof HTMLElement && e.target.nextElementSibling)
-                    (e.target.nextElementSibling as HTMLElement).style.display = "flex";
-                }}
-              />
+            {#if sidebarAvatarSrc}
+              <img src={sidebarAvatarSrc} alt="" class="sidebar-user-avatar-img" />
             {/if}
             <div
               class="sidebar-user-avatar"

--- a/apps/web/src/routes/(app)/settings/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/+page.svelte
@@ -22,7 +22,31 @@
 
   // Avatar
   let avatarUploading = $state(false);
-  let avatarKey = $state(0); // Force re-render after upload
+  let avatarKey = $state(0); // Force re-fetch after upload
+  let avatarSrc = $state<string | null>(null);
+
+  $effect(() => {
+    const empId = $authStore.user?.employeeId;
+    const token = $authStore.accessToken;
+    // avatarKey is read to re-run after upload
+    void avatarKey;
+    if (!empId || !token) return;
+
+    let objectUrl: string | null = null;
+    fetch(`/api/v1/avatars/${empId}`, { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => (r.ok ? r.blob() : null))
+      .then((blob) => {
+        if (blob) {
+          objectUrl = URL.createObjectURL(blob);
+          avatarSrc = objectUrl;
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  });
 
   onMount(async () => {
     try {
@@ -88,19 +112,8 @@
       <h3 class="section-title">Profilbild</h3>
       <div class="avatar-section">
         <div class="avatar-wrapper">
-          {#if $authStore.user?.employeeId}
-            {#key avatarKey}
-              <img
-                src="/api/v1/avatars/{$authStore.user.employeeId}?v={avatarKey}"
-                alt="Avatar"
-                class="avatar-preview"
-                onerror={(e) => {
-                  (e.target as HTMLImageElement).style.display = "none";
-                  const next = (e.target as HTMLElement).nextElementSibling;
-                  if (next) (next as HTMLElement).style.display = "flex";
-                }}
-              />
-            {/key}
+          {#if avatarSrc}
+            <img src={avatarSrc} alt="Avatar" class="avatar-preview" />
           {/if}
           <div class="avatar-initials" style={$authStore.user?.employeeId ? "display:none" : ""}>
             {($authStore.user?.firstName ?? $authStore.user?.email?.[0] ?? "?")


### PR DESCRIPTION
## Summary

- Profile pictures are personal data under DSGVO Art. 4 — previously accessible without any authentication
- **API**: `GET /avatars/:employeeId` now requires `requireAuth` + same-tenant check, `Cache-Control: private`
- **Web**: both sidebar and settings page load avatars via `fetch()` with `Authorization` header and create object URLs instead of bare `<img src="...">`

## Test plan
- [ ] Avatar visible in sidebar when logged in
- [ ] Avatar visible in settings page, updates after upload
- [ ] `GET /api/v1/avatars/:id` without token → 401
- [ ] `GET /api/v1/avatars/:id` with token from different tenant → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)