### PR TITLE
fix(api): handle Content-Type: application/json with empty body on DELETE requests

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -28,7 +28,7 @@ See: .planning/PROJECT.md (updated 2026-03-31 after v1.0 milestone)
 Phase: —
 Plan: —
 Status: v1.0 milestone complete — ready for next milestone planning
-Last activity: 2026-03-31
+Last activity: 2026-03-31 - Completed quick task 260331-piv: fix employee DSGVO anonymization DELETE returning 400 Content-Type empty body
 
 Progress: [██████████] 100%
 
@@ -41,6 +41,12 @@ All key decisions logged in PROJECT.md Key Decisions table.
 ### Pending Todos
 
 None.
+
+### Quick Tasks Completed
+
+| # | Description | Date | Commit | Directory |
+|---|-------------|------|--------|-----------|
+| 260331-piv | fix employee DSGVO anonymization DELETE returning 400 Content-Type empty body | 2026-03-31 | 4874122 | [260331-piv-fix-employee-dsgvo-anonymization-delete-](./quick/260331-piv-fix-employee-dsgvo-anonymization-delete-/) |
 
 ### Blockers/Concerns
 

--- a/.planning/quick/260331-piv-fix-employee-dsgvo-anonymization-delete-/260331-piv-PLAN.md
+++ b/.planning/quick/260331-piv-fix-employee-dsgvo-anonymization-delete-/260331-piv-PLAN.md
@@ -1,0 +1,148 @@
+---
+type: quick-fix
+scope: api
+files_modified:
+  - apps/api/src/app.ts
+  - apps/api/src/__tests__/employees.test.ts
+autonomous: true
+---
+
+<objective>
+Fix Fastify rejecting DELETE requests that include `Content-Type: application/json` with an empty body.
+
+Purpose: External API clients (MCP tools, Postman, curl, programmatic clients) commonly send `Content-Type: application/json` on all requests including DELETE. Fastify's default JSON parser rejects these with HTTP 400 "Body cannot be empty when content-type is set to 'application/json'". This affects ALL DELETE routes, not just the employee DSGVO anonymization endpoint.
+
+Output: App-level fix in `app.ts` that gracefully handles empty-body JSON DELETE requests, plus a regression test.
+</objective>
+
+<context>
+@apps/api/src/app.ts — Fastify app setup, where content type parsers are configured
+@apps/api/src/routes/employees.ts — DELETE /:id route (DSGVO anonymization, line 451)
+@apps/api/src/__tests__/employees.test.ts — Existing DSGVO anonymization tests (line 260)
+@apps/web/src/lib/api/client.ts — Web client correctly omits Content-Type on DELETE (line 23)
+
+Key finding: The web frontend does NOT trigger this bug (it only sets Content-Type when body is present). But any external client sending `Content-Type: application/json` on DELETE requests gets a 400 error. This is a correctness issue affecting the API contract.
+
+All 11 DELETE routes in the codebase are affected:
+- employees/:id, time-entries/:id, leave/requests/:id, holidays/:id
+- company-shutdowns/:id, terminals/:id, special-leave/rules/:id
+- shifts/templates/:id, shifts/:id, avatars/:employeeId, api-keys/:id
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Add app-level empty-body JSON parser and regression test</name>
+  <files>apps/api/src/app.ts, apps/api/src/__tests__/employees.test.ts</files>
+  <behavior>
+    - Test: DELETE /api/v1/employees/:id with `Content-Type: application/json` header and NO body returns 204 (not 400)
+    - Test: DELETE /api/v1/employees/:id WITHOUT Content-Type header still returns 204 (existing behavior preserved)
+    - Test: POST with valid JSON body still parses correctly (no regression)
+  </behavior>
+  <action>
+    1. In `apps/api/src/app.ts`, after the Fastify instance is created (after line 85 `const app = Fastify({...})`) and BEFORE any plugin registrations, add a custom content type parser that handles `application/json` with empty bodies gracefully:
+
+    ```typescript
+    // Handle DELETE (and other) requests that send Content-Type: application/json with empty body.
+    // External API clients commonly set this header on all requests.
+    app.addContentTypeParser(
+      "application/json",
+      { parseAs: "string" },
+      (req, body, done) => {
+        if (typeof body === "string" && body.trim() === "") {
+          done(null, undefined);
+          return;
+        }
+        try {
+          done(null, JSON.parse(body as string));
+        } catch (err) {
+          done(err as Error, undefined);
+        }
+      },
+    );
+    ```
+
+    This replaces Fastify's default JSON parser with one that:
+    - Returns `undefined` for empty string bodies (instead of throwing)
+    - Parses non-empty JSON normally
+    - Passes parse errors through (existing behavior for malformed JSON)
+
+    2. In `apps/api/src/__tests__/employees.test.ts`, inside the `COMPLIANCE: DSGVO anonymization (Art. 17)` describe block, add a new test case BEFORE the existing "DELETE anonymizes" test (since it consumes the test employee). Actually, since the existing test already deletes the employee, add the new test to a separate describe block or use a different employee. The simplest approach: add the test as part of the existing flow, testing that the Content-Type header is accepted.
+
+    Add this test after the existing "AuditLog records the anonymization" test (which runs after the DELETE already happened), OR better: create a small focused test that creates its own employee and tests the Content-Type scenario.
+
+    The cleanest approach: Add a focused `describe("DELETE with Content-Type: application/json header")` block that creates a minimal employee, sends a DELETE with the problematic header, and asserts 204. Place it after the existing DSGVO describe block (~line 310).
+
+    ```typescript
+    describe("DELETE with Content-Type: application/json (empty body)", () => {
+      it("accepts DELETE with Content-Type header and no body", async () => {
+        // Create a throwaway employee for this test
+        const uid = crypto.randomUUID().slice(0, 8);
+        const user = await app.prisma.user.create({
+          data: {
+            email: `ct-test-${uid}@test.local`,
+            passwordHash: "test",
+            role: "EMPLOYEE",
+            tenantId: data.tenantId,
+          },
+        });
+        const emp = await app.prisma.employee.create({
+          data: {
+            userId: user.id,
+            tenantId: data.tenantId,
+            firstName: "CT",
+            lastName: "Test",
+            employeeNumber: `CT-${uid}`,
+            hireDate: new Date("2024-01-01"),
+          },
+        });
+        await app.prisma.overtimeAccount.create({
+          data: { employeeId: emp.id, balanceHours: 0 },
+        });
+
+        const res = await app.inject({
+          method: "DELETE",
+          url: `/api/v1/employees/${emp.id}`,
+          headers: {
+            authorization: `Bearer ${data.adminToken}`,
+            "content-type": "application/json",
+          },
+        });
+
+        expect(res.statusCode).toBe(204);
+      });
+    });
+    ```
+
+    Make sure to import `crypto` at the top of the test file if not already imported (check first — the existing DSGVO test already uses `crypto.randomUUID()` so it likely is imported or uses the global).
+  </action>
+  <verify>
+    <automated>cd /Users/sebastianzabel/git/clokr && docker compose exec api npx vitest run src/__tests__/employees.test.ts --reporter=verbose 2>&1 | tail -40</automated>
+  </verify>
+  <done>
+    - DELETE requests with `Content-Type: application/json` and empty body return the expected status (204 for employee anonymization), not 400
+    - DELETE requests without Content-Type header continue to work (existing tests pass)
+    - POST/PUT/PATCH with JSON bodies continue to parse correctly (existing tests pass)
+    - New regression test covers the Content-Type + empty body scenario
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+Run the full employees test suite to confirm no regressions:
+```bash
+cd /Users/sebastianzabel/git/clokr && docker compose exec api npx vitest run src/__tests__/employees.test.ts --reporter=verbose
+```
+
+Optionally run the full API test suite to ensure the app-level parser change doesn't break other routes:
+```bash
+cd /Users/sebastianzabel/git/clokr && docker compose exec api npx vitest run --reporter=verbose
+```
+</verification>
+
+<success_criteria>
+- All existing employee tests pass (DSGVO anonymization, CRUD, etc.)
+- New test proves DELETE with Content-Type: application/json header succeeds
+- No regressions in other API tests (the custom JSON parser handles all existing use cases)
+</success_criteria>

--- a/.planning/quick/260331-piv-fix-employee-dsgvo-anonymization-delete-/260331-piv-SUMMARY.md
+++ b/.planning/quick/260331-piv-fix-employee-dsgvo-anonymization-delete-/260331-piv-SUMMARY.md
@@ -1,0 +1,85 @@
+---
+type: quick-fix
+quick_id: 260331-piv
+scope: api
+subsystem: http-layer
+tags: [fastify, content-type, delete, external-api, regression-test]
+dependency_graph:
+  requires: []
+  provides: [graceful-empty-body-json-delete]
+  affects: [all-delete-routes]
+tech_stack:
+  added: []
+  patterns: [custom-fastify-content-type-parser]
+key_files:
+  created: []
+  modified:
+    - apps/api/src/app.ts
+    - apps/api/src/__tests__/employees.test.ts
+decisions:
+  - App-level parser (not per-route) — fixes all 11 DELETE routes in one place
+  - Parse-as-string then manually JSON.parse — required by Fastify's content type parser API
+metrics:
+  duration: ~15 minutes
+  completed_date: "2026-03-31"
+  tasks_completed: 1
+  files_changed: 2
+---
+
+# Quick Fix 260331-piv: Fix Content-Type: application/json on DELETE Requests
+
+**One-liner:** App-level Fastify content-type parser that returns undefined for empty-body JSON requests instead of throwing HTTP 400.
+
+## Summary
+
+External API clients (MCP tools, Postman, curl, programmatic clients) commonly send `Content-Type: application/json` on ALL requests — including DELETE requests that have no body. Fastify's default JSON parser rejected these with HTTP 400 "Body cannot be empty when content-type is set to 'application/json'".
+
+This affected all 11 DELETE routes in the API. The fix adds a custom content-type parser at the app level in `app.ts` that handles the empty-body case gracefully by returning `undefined` (which route handlers ignore, as DELETE routes don't read the body).
+
+## Changes
+
+### apps/api/src/app.ts
+
+Added `app.addContentTypeParser("application/json", ...)` immediately after Fastify instance creation, before any plugin registrations. The parser:
+- Returns `undefined` for empty string bodies (graceful handling for DELETE)
+- Parses non-empty JSON strings normally via `JSON.parse()`
+- Passes parse errors through (malformed JSON still returns 400)
+
+### apps/api/src/__tests__/employees.test.ts
+
+Added a focused regression test in a new `describe("DELETE with Content-Type: application/json (empty body)")` block that:
+1. Creates a throwaway employee (user + employee + overtimeAccount)
+2. Sends DELETE with `Content-Type: application/json` header and no body
+3. Asserts 204 status (successful DSGVO anonymization)
+
+## TDD Flow
+
+- RED: New test failed with 400 before fix (Fastify rejected empty body)
+- GREEN: All 13 employees tests pass after adding custom content-type parser
+- No REFACTOR needed (implementation is clean as-is)
+
+## Commits
+
+| Hash | Type | Description |
+|------|------|-------------|
+| c6fe46c | fix | handle Content-Type: application/json with empty body on DELETE requests |
+
+## Deviations from Plan
+
+**1. [Rule 1 - Bug] Fixed test data: `tenantId` vs `tenant.id` and user without tenant**
+- **Found during:** Task 1 (GREEN phase)
+- **Issue:** Plan's test template used `data.tenantId` (undefined) and passed `tenantId` to user create. `seedTestData()` returns `tenant` object, not `tenantId` string. Users don't have a `tenantId` field.
+- **Fix:** Changed to `data.tenant.id` for employee create, removed `tenantId` from user create (matching the pattern used in the existing DSGVO test)
+- **Files modified:** `apps/api/src/__tests__/employees.test.ts`
+- **Commit:** c6fe46c (incorporated into same commit)
+
+## Known Stubs
+
+None.
+
+## Self-Check: PASSED
+
+- `apps/api/src/app.ts` — modified, content-type parser present
+- `apps/api/src/__tests__/employees.test.ts` — modified, new test present
+- Commit `c6fe46c` — exists in git log
+- All 13 employees tests pass in container

--- a/apps/api/src/__tests__/employees.test.ts
+++ b/apps/api/src/__tests__/employees.test.ts
@@ -306,6 +306,44 @@ describe("Employees API", () => {
     });
   });
 
+  describe("DELETE with Content-Type: application/json (empty body)", () => {
+    it("accepts DELETE with Content-Type header and no body", async () => {
+      // Create a throwaway employee for this test
+      const uid = crypto.randomUUID().slice(0, 8);
+      const user = await app.prisma.user.create({
+        data: {
+          email: `ct-test-${uid}@test.local`,
+          passwordHash: "test",
+          role: "EMPLOYEE",
+        },
+      });
+      const emp = await app.prisma.employee.create({
+        data: {
+          userId: user.id,
+          tenantId: data.tenant.id,
+          firstName: "CT",
+          lastName: "Test",
+          employeeNumber: `CT-${uid}`,
+          hireDate: new Date("2024-01-01"),
+        },
+      });
+      await app.prisma.overtimeAccount.create({
+        data: { employeeId: emp.id, balanceHours: 0 },
+      });
+
+      const res = await app.inject({
+        method: "DELETE",
+        url: `/api/v1/employees/${emp.id}`,
+        headers: {
+          authorization: `Bearer ${data.adminToken}`,
+          "content-type": "application/json",
+        },
+      });
+
+      expect(res.statusCode).toBe(204);
+    });
+  });
+
   it("COMPLIANCE: all SMTP passwords are encrypted", async () => {
     const configs = await app.prisma.tenantConfig.findMany({
       where: { smtpPassword: { not: null } },

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -84,6 +84,21 @@ export async function buildApp() {
     genReqId: () => crypto.randomUUID(), // Consistent request IDs
   });
 
+  // ── Content-Type Parser ───────────────────────────────────
+  // Handle DELETE (and other) requests that send Content-Type: application/json with empty body.
+  // External API clients (MCP tools, Postman, curl) commonly set this header on all requests.
+  app.addContentTypeParser("application/json", { parseAs: "string" }, (req, body, done) => {
+    if (typeof body === "string" && body.trim() === "") {
+      done(null, undefined);
+      return;
+    }
+    try {
+      done(null, JSON.parse(body as string));
+    } catch (err) {
+      done(err as Error, undefined);
+    }
+  });
+
   // ── Security ──────────────────────────────────────────────
   // Global error handler: ZodErrors → 400 with German field messages
   app.setErrorHandler(


### PR DESCRIPTION
## Summary

- Fixes `DELETE /api/v1/employees/:id` (DSGVO anonymization) returning 400 `"Body cannot be empty when content-type is set to 'application/json'"` when clients send `Content-Type: application/json` without a body
- Added app-level custom `addContentTypeParser` in `app.ts` that returns `undefined` for empty bodies instead of throwing — fixes all 11 DELETE routes
- Added regression test in `employees.test.ts` that sends DELETE with the problematic `Content-Type: application/json` header and asserts 204

## Root Cause

Fastify's default JSON parser throws when it receives `Content-Type: application/json` with an empty body. External API clients (MCP tools, Postman, curl, HTTP libraries) commonly set `Content-Type: application/json` on all requests regardless of method. The web frontend's `api.delete()` was unaffected (it correctly omits Content-Type when there's no body), but any other client hitting the API would fail.

## Test Plan

- [ ] `DELETE /api/v1/employees/:id` with `Content-Type: application/json` (no body) returns 204 (regression test added)
- [ ] Existing employee delete (DSGVO anonymization) works from browser UI
- [ ] Other DELETE routes still work correctly

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)