### PR TITLE
fix(ui): accessibility & UX polish — 9/10 issues from UI/UX review

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -88,7 +88,7 @@
 
   /* Text — warm stone tones from CD */
   --color-text: #44403c;
-  --color-text-muted: #78746c;
+  --color-text-muted: #6b6760; /* darkened from #78746c — WCAG AA 4.5:1 on --color-bg */
   --color-text-heading: #1c1917;
 
   /* Border */
@@ -748,11 +748,16 @@ button {
 }
 
 select.form-input {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2378746c' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%236b6760' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 0.75rem center;
   padding-right: 2.5rem;
   cursor: pointer;
+}
+
+/* Nacht (dark) theme: chevron must be light enough to be visible on dark surface */
+[data-theme="nacht"] select.form-input {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238b949e' stroke-width='2'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
 }
 
 .form-hint {

--- a/apps/web/src/lib/components/ui/Toast.svelte
+++ b/apps/web/src/lib/components/ui/Toast.svelte
@@ -12,6 +12,10 @@
   // Only show the last 5 toasts
   let visible = $derived(items.slice(-5));
 
+  // Respect prefers-reduced-motion — CSS override does not affect JS-driven Svelte transitions
+  const reducedMotion =
+    typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
   // Map toast type to status color CSS variable prefix
   function colorVar(type: Toast["type"]): string {
     switch (type) {
@@ -32,9 +36,9 @@
     {#each visible as toast (toast.id)}
       <div
         class="toast toast-{toast.type}"
-        animate:flip={{ duration: 250 }}
-        in:fly={{ x: 360, duration: 350, easing: (t) => 1 - Math.pow(1 - t, 3) }}
-        out:fly={{ x: 360, duration: 250, easing: (t) => t * t }}
+        animate:flip={{ duration: reducedMotion ? 0 : 250 }}
+        in:fly={{ x: reducedMotion ? 0 : 360, duration: reducedMotion ? 0 : 350, easing: (t) => 1 - Math.pow(1 - t, 3) }}
+        out:fly={{ x: reducedMotion ? 0 : 360, duration: reducedMotion ? 0 : 250, easing: (t) => t * t }}
         style="
           --toast-color: var(--color-{colorVar(toast.type)});
           --toast-bg: var(--color-{colorVar(toast.type)}-bg);
@@ -152,6 +156,7 @@
     word-break: break-word;
   }
 
+  /* Visual size stays 24×24, hit area extended to 44×44 via padding (WCAG 2.5.5) */
   .toast-close {
     flex-shrink: 0;
     display: flex;
@@ -164,8 +169,8 @@
     color: var(--color-text-muted);
     cursor: pointer;
     border-radius: 4px;
-    padding: 0;
-    margin: -2px -4px -2px 0;
+    padding: 10px;
+    margin: -10px -10px -10px 0;
     transition:
       background-color 0.15s,
       color 0.15s;

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -474,7 +474,7 @@
   /* ── Shell ─────────────────────────────────────────────────────────── */
   .app-shell {
     display: flex;
-    min-height: 100vh;
+    min-height: 100dvh;
     background-color: var(--color-bg);
   }
 
@@ -491,7 +491,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    height: 100vh;
+    height: 100dvh;
     z-index: 100;
     overflow-y: auto;
   }
@@ -693,9 +693,8 @@
   }
 
   .notification-item-time {
-    font-size: 0.6875rem;
+    font-size: 0.75rem; /* increased from 0.6875rem (11px) — opacity+tiny size fails contrast */
     color: var(--color-text-muted);
-    opacity: 0.7;
   }
 
   /* ── Nav ───────────────────────────────────────────────────────────── */
@@ -759,11 +758,10 @@
   }
 
   .sidebar-version {
-    font-size: 0.6875rem;
+    font-size: 0.75rem; /* increased from 0.6875rem (11px) — opacity+tiny size fails contrast */
     color: var(--color-text-muted);
     text-align: center;
     margin: 0;
-    opacity: 0.6;
   }
 
   .sidebar-user {
@@ -846,8 +844,9 @@
   .app-main {
     flex: 1;
     margin-left: 240px;
+    margin-right: auto;
     padding: 2rem;
-    min-height: 100vh;
+    min-height: 100dvh;
     min-width: 0;
     max-width: 1400px;
     padding-bottom: 5rem; /* space for mobile nav */

--- a/apps/web/src/routes/(app)/dashboard/+page.svelte
+++ b/apps/web/src/routes/(app)/dashboard/+page.svelte
@@ -89,6 +89,7 @@
   let clockedIn = $state(false);
   let activeEntryId: string | null = null;
   let loading = $state(false);
+  let chartsLoading = $state(true);
   let clockLoading = $state(false);
   let breakMinutes = $state(0);
   let recentEntries: { id: string; endTime: string | null; startTime: string }[] = $state([]);
@@ -548,6 +549,8 @@
       }
     } catch (err) {
       console.error("Failed to load chart data:", err);
+    } finally {
+      chartsLoading = false;
     }
   }
 
@@ -987,21 +990,33 @@
       <div class="chart-card card card-body card-animate">
         <h3 class="chart-title">Arbeitsstunden (6 Monate)</h3>
         <div class="chart-wrap">
-          <canvas bind:this={weeklyChartEl}></canvas>
+          {#if chartsLoading}
+            <div class="chart-skeleton" aria-hidden="true"></div>
+          {:else}
+            <canvas bind:this={weeklyChartEl} role="img" aria-label="Balkendiagramm: gearbeitete Stunden der letzten 6 Monate"></canvas>
+          {/if}
         </div>
       </div>
 
       <div class="chart-card card card-body card-animate">
         <h3 class="chart-title">Überstunden-Trend</h3>
         <div class="chart-wrap">
-          <canvas bind:this={overtimeChartEl}></canvas>
+          {#if chartsLoading}
+            <div class="chart-skeleton" aria-hidden="true"></div>
+          {:else}
+            <canvas bind:this={overtimeChartEl} role="img" aria-label="Liniendiagramm: Überstunden-Verlauf der letzten 6 Monate"></canvas>
+          {/if}
         </div>
       </div>
 
       <div class="chart-card card card-body card-animate">
         <h3 class="chart-title">Krankheitstage (6 Monate)</h3>
         <div class="chart-wrap">
-          <canvas bind:this={sickChartEl}></canvas>
+          {#if chartsLoading}
+            <div class="chart-skeleton" aria-hidden="true"></div>
+          {:else}
+            <canvas bind:this={sickChartEl} role="img" aria-label="Balkendiagramm: Krankheitstage der letzten 6 Monate"></canvas>
+          {/if}
         </div>
       </div>
     </div>
@@ -1687,6 +1702,25 @@
   .chart-wrap {
     position: relative;
     height: 240px;
+  }
+
+  .chart-skeleton {
+    width: 100%;
+    height: 100%;
+    border-radius: var(--radius-sm);
+    background: linear-gradient(
+      90deg,
+      var(--color-bg-subtle) 25%,
+      var(--color-bg-muted) 50%,
+      var(--color-bg-subtle) 75%
+    );
+    background-size: 200% 100%;
+    animation: skeleton-shimmer 1.4s ease-in-out infinite;
+  }
+
+  @keyframes skeleton-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
   }
 
   .upcoming-section {

--- a/apps/web/src/routes/(auth)/einladung/+page.svelte
+++ b/apps/web/src/routes/(auth)/einladung/+page.svelte
@@ -162,7 +162,7 @@
 
 <style>
   .login-page {
-    min-height: 100vh;
+    min-height: 100dvh;
     background-color: var(--color-bg-subtle);
     display: flex;
     align-items: center;

--- a/apps/web/src/routes/(auth)/forgot-password/+page.svelte
+++ b/apps/web/src/routes/(auth)/forgot-password/+page.svelte
@@ -88,7 +88,7 @@
 
 <style>
   .login-page {
-    min-height: 100vh;
+    min-height: 100dvh;
     background-color: var(--color-bg-subtle);
     display: flex;
     align-items: center;

--- a/apps/web/src/routes/(auth)/login/+page.svelte
+++ b/apps/web/src/routes/(auth)/login/+page.svelte
@@ -288,7 +288,7 @@
 
 <style>
   .login-page {
-    min-height: 100vh;
+    min-height: 100dvh;
     background: var(--color-bg);
     display: flex;
     align-items: stretch;
@@ -342,7 +342,7 @@
   .login-container {
     display: flex;
     width: 100%;
-    min-height: 100vh;
+    min-height: 100dvh;
     position: relative;
     z-index: 1;
   }

--- a/apps/web/src/routes/(auth)/otp/+page.svelte
+++ b/apps/web/src/routes/(auth)/otp/+page.svelte
@@ -142,7 +142,7 @@
 
 <style>
   .login-page {
-    min-height: 100vh;
+    min-height: 100dvh;
     background-color: var(--color-bg-subtle);
     display: flex;
     align-items: center;

--- a/apps/web/src/routes/(auth)/reset-password/+page.svelte
+++ b/apps/web/src/routes/(auth)/reset-password/+page.svelte
@@ -136,7 +136,7 @@
 
 <style>
   .login-page {
-    min-height: 100vh;
+    min-height: 100dvh;
     background-color: var(--color-bg-subtle);
     display: flex;
     align-items: center;


### PR DESCRIPTION
Closes #136

## Summary

- Fix Svelte `fly`/`flip` transitions to respect `prefers-reduced-motion` (CSS override doesn't affect JS transitions)
- Replace `100vh` → `100dvh` on all auth pages and app shell (iOS Safari viewport clipping)
- Extend Toast close button hit area from 24×24 to 44×44px (WCAG 2.5.5)
- Darken `--color-text-muted` from `#78746c` → `#6b6760` for WCAG AA 4.5:1 on Pflaume theme
- Remove opacity reduction + increase font size on `.notification-item-time` and `.sidebar-version` (were 11px + opacity 0.6–0.7)
- Add `role="img"` + `aria-label` to all 3 dashboard chart canvases
- Add shimmer skeleton for chart cards while data loads
- Fix select chevron invisible in Nacht (dark) theme
- Center `.app-main` on ultra-wide screens with `margin-right: auto`

## Not included
- Notification dropdown extraction to component — deferred to follow-up issue

## Test plan
- [ ] Enable `prefers-reduced-motion` in OS — toasts appear/disappear without animation
- [ ] Open any auth page on iOS Safari — no content clipped behind browser chrome
- [ ] Tap the toast close ×  on mobile — hit area is comfortably 44×44
- [ ] Toggle Nacht theme — select dropdowns show visible chevron
- [ ] Dashboard loads as manager — chart skeletons shimmer, then charts appear
- [ ] Run axe or Lighthouse accessibility audit — no contrast errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)