### PR TITLE
fix(dashboard): clock-in button silent failure + active state not loading

### DIFF
--- a/apps/api/src/routes/dashboard.ts
+++ b/apps/api/src/routes/dashboard.ts
@@ -16,8 +16,17 @@ export async function dashboardRoutes(app: FastifyInstance) {
   app.get("/", {
     schema: { tags: ["Dashboard"], security: [{ bearerAuth: [] }] },
     preHandler: requireAuth,
-    handler: async (req) => {
-      const employeeId = req.user.employeeId!;
+    handler: async (req, reply) => {
+      const employeeId = req.user.employeeId;
+      if (!employeeId) {
+        // API-only users (no employee record) receive empty stats rather than a Prisma crash
+        return reply.code(200).send({
+          today: { workedHours: 0, entries: 0 },
+          week: { workedHours: 0, targetHours: 0 },
+          overtime: { balanceHours: 0 },
+          vacation: { remaining: 0, total: 0, used: 0 },
+        });
+      }
       const tenantId = req.user.tenantId;
       const tz = await getTenantTimezone(app.prisma, tenantId);
       const now = new Date();

--- a/apps/web/src/routes/(app)/dashboard/+page.svelte
+++ b/apps/web/src/routes/(app)/dashboard/+page.svelte
@@ -20,6 +20,7 @@
   import { onMount, onDestroy } from "svelte";
   import { api } from "$api/client";
   import { authStore } from "$stores/auth";
+  import { toasts } from "$stores/toast";
   import { format, subMonths } from "date-fns";
   import { de } from "date-fns/locale";
   import {
@@ -87,7 +88,7 @@
 
   // ── State ──────────────────────────────────────────────────────────────────
   let clockedIn = $state(false);
-  let activeEntryId: string | null = null;
+  let activeEntryId = $state<string | null>(null);
   let loading = $state(false);
   let chartsLoading = $state(true);
   let clockLoading = $state(false);
@@ -192,26 +193,36 @@
     try {
       const today = format(new Date(), "yyyy-MM-dd");
 
-      // Parallel laden
-      const [entries, dashStats] = await Promise.all([
+      // Parallel laden — allSettled so a stats failure doesn't break clock state
+      const [entriesResult, statsResult] = await Promise.allSettled([
         api.get<{ id: string; endTime: string | null; startTime: string }[]>(
           `/time-entries?from=${today}&to=${today}`,
         ),
         api.get<DashboardStats>("/dashboard"),
       ]);
 
-      recentEntries = entries;
-      stats = dashStats;
-
-      const openEntry = entries.find((e) => !e.endTime);
-      if (openEntry) {
-        clockedIn = true;
-        activeEntryId = openEntry.id;
-        clockStart = new Date(openEntry.startTime);
+      if (entriesResult.status === "fulfilled") {
+        const entries = entriesResult.value;
+        recentEntries = entries;
+        const openEntry = entries.find((e) => !e.endTime);
+        if (openEntry) {
+          clockedIn = true;
+          activeEntryId = openEntry.id;
+          clockStart = new Date(openEntry.startTime);
+        } else {
+          clockedIn = false;
+          activeEntryId = null;
+          clockStart = null;
+        }
       } else {
-        clockedIn = false;
-        activeEntryId = null;
-        clockStart = null;
+        console.error("Failed to load time entries:", entriesResult.reason);
+        toasts.error("Zeiteinträge konnten nicht geladen werden");
+      }
+
+      if (statsResult.status === "fulfilled") {
+        stats = statsResult.value;
+      } else {
+        console.error("Failed to load dashboard stats:", statsResult.reason);
       }
 
       // Load today's shift
@@ -573,6 +584,8 @@
         breakMinutes = 0;
       }
       await loadData();
+    } catch (err) {
+      toasts.error(err instanceof Error ? err.message : "Fehler beim Stempeln");
     } finally {
       clockLoading = false;
     }
@@ -615,7 +628,7 @@
   let userName = $derived($authStore.user?.firstName ?? $authStore.user?.email.split("@")[0] ?? "");
   let capitalizedName = $derived(userName.charAt(0).toUpperCase() + userName.slice(1));
 
-  let overtimeBalance = $derived(stats?.overtime.balanceHours ?? 0);
+  let overtimeBalance = $derived((stats as DashboardStats | null)?.overtime?.balanceHours ?? 0);
   let overtimeClass = $derived(
     Math.abs(overtimeBalance) >= 60
       ? "text-red"


### PR DESCRIPTION
## Summary

- **Bug 1:** `handleClock()` had `try/finally` but no `catch` — every API error (409, 403, network) was silently swallowed. The only visible effect was the CSS press animation (`.btn:active { transform: translateY(1px) }`), making it look like the button did nothing.
- **Bug 2:** `GET /dashboard` crashed with a Prisma error when `req.user.employeeId` was `undefined` (API-only users or stale JWTs). This caused `Promise.all` in `loadData()` to reject, so `clockedIn` was never derived from open time entries — the dashboard showed "Einstempeln" even when the user was already clocked in.

The two bugs combined: dashboard loads, shows wrong state (clocked out), user clicks Einstempeln, API returns 409 "Bereits eingestempelt", error is swallowed — nothing visible happens.

## Changes

**`apps/api/src/routes/dashboard.ts`**
- Removed `!` non-null assertion on `employeeId`
- Early return with empty-but-valid stats when `employeeId` is undefined — prevents Prisma crash for API-only users

**`apps/web/src/routes/(app)/dashboard/+page.svelte`**
- Added `catch` block in `handleClock()` with `toasts.error()` for user-visible error feedback
- Switched `Promise.all` → `Promise.allSettled` in `loadData()` so clock state loads independently of stats
- `activeEntryId` changed to `$state<string|null>` for proper Svelte 5 reactivity
- TypeScript fix: explicit cast for `stats?.overtime.balanceHours` to resolve `$derived` inference issue

## Test plan

- [ ] Deploy with `docker compose up --build -d`
- [ ] Open dashboard — if already clocked in, "Ausstempeln" widget should show correctly
- [ ] Click "Einstempeln" when already clocked in → red toast with "Bereits eingestempelt"
- [ ] Click "Einstempeln" when clocked out → spinner, then switches to "Ausstempeln" timer
- [ ] Verify no regression on stats display (overtime balance, vacation, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)