### PR TITLE
refactor(ui): unify Zeiterfassung + Abwesenheiten calendar styles

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,7 +5,7 @@ milestone_name: milestone
 status: planning
 stopped_at: Completed 260411-086-03-PLAN.md
 last_updated: "2026-04-10T22:45:33.576Z"
-last_activity: "2026-04-11 - Completed quick task 260411-drh: Allow early employee deletion before 10-year retention period with admin acknowledgement"
+last_activity: "2026-04-11 - Completed quick task 260411-g4n: Build shared calendar base component to unify CSS class names between Zeiterfassung and Abwesenheiten calendars"
 progress:
   percent: 100
 ---
@@ -24,7 +24,7 @@ See: .planning/PROJECT.md (updated 2026-03-31 after v1.0 milestone)
 Phase: —
 Plan: —
 Status: v1.0 milestone complete — ready for next milestone planning
-Last activity: 2026-04-11 - Completed quick task 260411-dz9: Employee exit date (Austrittsdatum), pro-rata vacation entitlement, warning when leave exceeds entitlement
+Last activity: 2026-04-11 - Completed quick task 260411-g4n: Unified calendar CSS class names (Zeiterfassung + Abwesenheiten)
 
 Progress: [██████████] 100%
 
@@ -56,6 +56,7 @@ None.
 | 260411-drh | Allow early employee deletion before 10-year retention period with admin acknowledgement checkbox                                                                                                 | 2026-04-11 | 11287e0 | [260411-drh-allow-early-employee-deletion-before-10-](./quick/260411-drh-allow-early-employee-deletion-before-10-/)       |
 | 260411-dz9 | Employee exit date (Austrittsdatum): configurable per employee, pro-rata vacation entitlement calculation, warning when taken/approved leave exceeds entitlement                                  | 2026-04-11 | 91e50b2 | [260411-dz9-employee-exit-date-austrittsdatum-config](./quick/260411-dz9-employee-exit-date-austrittsdatum-config/)       |
 | 260411-fth | Use CSS vars for leave-type colors + align employee-selector style (typeColor, legend dots, time-entries employee-selector)                                                                       | 2026-04-11 | 5883486 | [260411-fth-fix-leave-type-colors-and-employee-selector](./quick/260411-fth-fix-leave-type-colors-and-employee-selector/) |
+| 260411-g4n | Unify calendar CSS class names between Zeiterfassung and Abwesenheiten calendars (shared canonical class set, consolidated app.css rules)                                                         | 2026-04-11 | 834fdd8 | [260411-g4n-build-shared-calendar-base-component-to-](./quick/260411-g4n-build-shared-calendar-base-component-to-/)       |
 
 ### Blockers/Concerns
 

--- a/.planning/UI_STYLE_GUIDE.md
+++ b/.planning/UI_STYLE_GUIDE.md
@@ -369,6 +369,58 @@ When `pageSize` changes, the component resets `page = 1` internally and then cal
 
 ---
 
+## CSS Architecture: Global vs Scoped
+
+### Decision rule
+
+| What | Where | Why |
+|------|-------|-----|
+| Design tokens (`--color-*`, `--font-*`, etc.) | `app.css` | Single source of truth, resolved at runtime |
+| Shared class bases used by **≥ 2 components** (e.g. `.cal-cell`, `.cal-today`) | `app.css` | One place to change, no cascade fights |
+| Component-specific layout, spacing, variants | Component `<style>` block | Scoped by Svelte hash, isolated |
+| Hover/focus/active states that are purely local | Component `<style>` block | No risk of leaking |
+| Library/third-party overrides | Component `<style>` with `.wrapper :global { }` | Minimally invasive |
+
+### Svelte scoping gotchas
+
+Svelte injects a `.svelte-HASH` selector on every scoped rule, giving it **+1 class specificity** over a matching global rule — even when both have `!important`. Component styles always win if specificity is equal.
+
+**Consequence:** if an `app.css` rule and a component `:global()` rule target the same selector, the component rule wins regardless of source order. Fix: move the rule to `app.css` entirely.
+
+**Compound `:global()` selectors are broken.** Svelte cannot correctly hash compound selectors that mix scoped and global parts:
+
+```svelte
+/* BAD — Svelte filters this out, rule never applies */
+:global(.cal-cell.cal-selected:not(.cal-other)) { ... }
+
+/* GOOD — put it in app.css directly, no wrapper needed */
+```
+
+Only use `:global()` in a component when overriding a child component's internals from a parent, and always wrap it tightly:
+
+```svelte
+<style>
+  .wrapper :global(.third-party-class) { ... }  /* ✓ scoped to .wrapper */
+</style>
+```
+
+### Naming conventions
+
+| Class type | Convention | Example |
+|------------|------------|---------|
+| Shared global (multi-component) | `domain-concept` | `.cal-cell`, `.cal-today`, `.month-summary` |
+| Component-private | short, descriptive | `.cell`, `.nav`, `.chip` |
+| State modifiers | `cal-` prefix for shared states | `.cal-selected`, `.cal-other`, `.cal-weekend` |
+| BEM variants | only inside a component | `.card__header`, `.card--highlighted` |
+
+### Avoiding `!important` wars
+
+- **Do not use `!important` in `app.css`** for anything except explicit state overrides (weekend bg, today ring, etc.) — document each one with a comment explaining why.
+- Component scoped rules never need `!important` to beat global defaults (they win via specificity).
+- If two rules both need `!important`, the one with **higher specificity** wins; same specificity = the one injected later (component > app.css). Resolve by moving the authoritative rule to `app.css` and deleting the duplicate.
+
+---
+
 ## Accessibility Checklist
 
 - [ ] All interactive elements: `min-height: 44px` (WCAG 2.5.5)

--- a/.planning/quick/260411-g4n-build-shared-calendar-base-component-to-/260411-g4n-PLAN.md
+++ b/.planning/quick/260411-g4n-build-shared-calendar-base-component-to-/260411-g4n-PLAN.md
@@ -1,0 +1,444 @@
+---
+phase: 260411-g4n
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/web/src/routes/(app)/time-entries/+page.svelte
+  - apps/web/src/routes/(app)/leave/+page.svelte
+  - apps/web/src/app.css
+autonomous: false
+requirements:
+  - G4N-01  # Unify calendar CSS class names across Zeiterfassung + Abwesenheiten
+  - G4N-02  # Simplify shared calendar selectors in app.css (single canonical set)
+
+must_haves:
+  truths:
+    - "Zeiterfassung calendar (time-entries) and Abwesenheiten calendar (leave) use the SAME CSS class names for wrapper, day number, weekend, holiday, other-month, today, selected, and current-month states"
+    - "Global app.css calendar rules reference ONE canonical selector per concept (no more dual `.cal-day.is-holiday, .cal-holiday` style selectors)"
+    - "Zeiterfassung calendar still renders correctly: day numbers, holiday labels, absence-type chips, +/- saldo, weekend/today/selected highlighting, ArbZG warnings, before-hire disabled state, absence-type backgrounds (Urlaub/Krank/Sonderurlaub/Freizeitausgl./Bildung/Unbezahlt)"
+    - "Abwesenheiten calendar still renders correctly: absence chips, drag-select highlighting, holiday labels, weekend background, today border, other-month dimming"
+    - "Both calendars still respond correctly to theme switching (pflaume/nacht/wald/schiefer/pro) via CSS custom properties"
+    - "No broken `:global()` selectors — all Zeiterfassung-specific global overrides still apply with new class names"
+  artifacts:
+    - path: "apps/web/src/routes/(app)/time-entries/+page.svelte"
+      provides: "Zeiterfassung calendar using canonical class names"
+      contains: 'class="cal-cell'
+    - path: "apps/web/src/routes/(app)/leave/+page.svelte"
+      provides: "Abwesenheiten calendar using canonical class names (already mostly aligned)"
+      contains: 'class="cal-cell'
+    - path: "apps/web/src/app.css"
+      provides: "Single canonical selector per concept for shared calendar rules"
+      contains: '.cal-cell.cal-holiday'
+  key_links:
+    - from: "apps/web/src/app.css"
+      to: "both calendar pages"
+      via: "single canonical class selector"
+      pattern: '\.cal-cell\.cal-holiday[^,]'
+    - from: "apps/web/src/routes/(app)/time-entries/+page.svelte template"
+      to: "time-entries/+page.svelte <style> block"
+      via: "class names match between markup and scoped styles"
+      pattern: 'class:cal-today'
+---
+
+<objective>
+Unify the CSS class naming conventions between the Zeiterfassung (time-entries) calendar and the Abwesenheiten (leave) calendar so both use a single canonical class set. This eliminates the current dual-naming situation in `app.css` where shared rules require selectors like `.cal-day.is-holiday, .cal-holiday` — after this change, each concept has exactly one selector.
+
+**Approach (per research findings):** NOT a shared Svelte component. Two calendars have fundamentally different content (time-entry data vs. leave chips with drag-select). Unifying CSS class names only gives us the DRY benefit in global styles without forcing a brittle shared component with too many slots.
+
+**Canonical class names (target):**
+
+| Concept              | Old (time-entries)  | Old (leave)          | **Canonical (both)** |
+| -------------------- | ------------------- | -------------------- | -------------------- |
+| Cell wrapper         | `.cal-day`          | `.cal-cell`          | `.cal-cell`          |
+| Day number           | `.day-num`          | `.cal-day-num`       | `.cal-day-num`       |
+| Holiday label        | `.day-holiday-name` | `.cal-holiday-label` | `.cal-holiday-label` |
+| Weekend state        | `.is-weekend`       | `.cal-weekend`       | `.cal-weekend`       |
+| Holiday state        | `.is-holiday`       | `.cal-holiday`       | `.cal-holiday`       |
+| Other month state    | `.other-month`      | `.cal-other`         | `.cal-other`         |
+| Today state          | `.is-today`         | `.cal-today`         | `.cal-today`         |
+| Current month state  | (none)              | `.cal-cell--current` | `.cal-current`       |
+| Selected state       | `.is-selected`      | (none)               | `.cal-selected`      |
+| Absence-type mod     | `.cal-day--abs-*`   | (none)               | `.cal-abs-*`         |
+
+Zeiterfassung-specific modifiers that stay in the time-entries scoped styles (no change needed beyond the wrapper rename): `.cal-day--ok`, `.cal-day--partial`, `.cal-day--missing`, `.cal-day--today-ok`, `.cal-day--today-partial`, `.cal-day--disabled`, `.cal-day--arbzg-warn`. These can either be kept with the `cal-day--` prefix OR renamed to `cal-cell--`. **Decision: rename to `cal-cell--` for consistency** (they live in scoped styles on one file, so the change is contained).
+
+Leave-specific modifiers that stay in the leave scoped styles: `.cal-cell--drag-selected`, `.cal-chip`, `.cal-chip-name`, `.cal-chip-type`, `.cal-chip--pending`, `.cal-chip--own`. No change needed.
+
+Purpose: Reduce CSS duplication, make it easier to add new shared calendar styles (one rule applies to both calendars), and establish a convention for future calendar-like views.
+
+Output: Both calendar pages compile and render identically to before, `app.css` has simplified shared selectors, no visual regressions across all themes.
+</objective>
+
+<execution_context>
+@/Users/sebastianzabel/git/clokr/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/sebastianzabel/git/clokr/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@CLAUDE.md
+@.planning/STATE.md
+@apps/web/src/routes/(app)/time-entries/+page.svelte
+@apps/web/src/routes/(app)/leave/+page.svelte
+@apps/web/src/app.css
+
+<interfaces>
+<!-- Key locations the executor needs. No codebase exploration required. -->
+
+## time-entries/+page.svelte (2210 lines)
+
+### Template — calendar markup
+Lines 940-1021 — the `{#if teView === "calendar"}` block containing:
+- Cell wrapper `<div class="cal-day cal-day--{day.status}...">` at lines 957-985 with class:* directives
+- Inner spans: `.day-num`, `.day-holiday-name`, `.day-abs-type`, `.day-before-hire`, `.day-worked`, `.day-bal`, `.day-missing`
+- Note: `.day-before-hire`, `.day-worked`, `.day-bal`, `.day-missing` are Zeiterfassung-specific content and are NOT in the canonical rename list — they stay as-is.
+
+### Scoped styles
+Lines ~1527-1660 (desktop): `.cal-day`, `.cal-day:nth-child(7n)`, `:global(.cal-day.other-month)`, `:global(.cal-day.cal-day--disabled)`, `:global(.cal-day.cal-day--arbzg-warn)`, `.cal-day:not(.other-month):hover`, `.cal-day.is-today`, `:global(.cal-day.is-selected:not(.other-month))`, `:global(.cal-day.is-selected:not(.other-month) .day-num)` etc., `.day-holiday-name`, `.cal-day--ok/partial/missing/today-ok/today-partial`, `.day-abs-type`, `.day-num`, `.is-today .day-num`.
+
+Lines ~2170-2200 (mobile @media block): `.cal-day`, `.day-num`, `.day-holiday-name`, `.day-abs-type`.
+
+### grep count: 42 occurrences of the old-name tokens in this file.
+
+## leave/+page.svelte (2886 lines)
+
+### Template — calendar markup
+Lines 1320-1450 — the calendar block. Already uses `.cal-cell`, `.cal-day-num`, `.cal-holiday-label`, `.cal-weekend`, `.cal-holiday`, `.cal-other`, `.cal-today`, `.cal-cell--current`, `.cal-cell--drag-selected`.
+
+### Scoped styles
+Lines ~2661-2720 (the range the researcher found; up to ~2803). `.cal-cell`, `.cal-cell:nth-child(7n)`, `:global(.cal-cell.cal-other)`, `.cal-today`, `.cal-cell--current`, `.cal-cell--current:hover`, `.cal-cell--drag-selected`, `.cal-day-num`, `.cal-today .cal-day-num`, `.cal-holiday-label`, `.cal-chip*`.
+
+### Changes needed in leave/+page.svelte
+Minimal — only two renames to hit the canonical set:
+- `.cal-cell--current` → `.cal-current` (template + styles)
+- No other changes (already uses canonical names)
+
+### grep count: 18 occurrences in leave/+page.svelte for the new-name tokens.
+
+## app.css (1732 lines)
+
+### Lines 1685-1721 — shared calendar rules block
+```css
+/* ─── Calendar shared: holiday + weekend cells ───────── */
+.cal-day.is-holiday:not(.other-month):not(.is-selected),
+.cal-holiday {
+  background: var(--color-brand-tint) !important;
+  border-left: 3px solid var(--color-brand);
+}
+
+.cal-day.is-weekend:not(.is-selected),
+.cal-cell.cal-weekend:not(.cal-other) {
+  background: var(--color-bg-subtle) !important;
+}
+
+/* ─── Leave-type absence cell backgrounds (used by cal-day--abs-* in Zeiterfassung) ── */
+.cal-day.cal-day--abs-vacation:not(.is-selected) { ... }
+.cal-day.cal-day--abs-sick:not(.is-selected) { ... }
+.cal-day.cal-day--abs-special:not(.is-selected) { ... }
+.cal-day.cal-day--abs-overtime_comp:not(.is-selected) { ... }
+.cal-day.cal-day--abs-education:not(.is-selected) { ... }
+.cal-day.cal-day--abs-unpaid:not(.is-selected) { ... }
+```
+
+### Target (after unification)
+```css
+/* ─── Calendar shared: holiday + weekend cells ───────── */
+.cal-cell.cal-holiday:not(.cal-other):not(.cal-selected) {
+  background: var(--color-brand-tint) !important;
+  border-left: 3px solid var(--color-brand);
+}
+
+.cal-cell.cal-weekend:not(.cal-other):not(.cal-selected) {
+  background: var(--color-bg-subtle) !important;
+}
+
+/* ─── Leave-type absence cell backgrounds (used by cal-abs-* in Zeiterfassung) ── */
+.cal-cell.cal-abs-vacation:not(.cal-selected) { ... }
+.cal-cell.cal-abs-sick:not(.cal-selected) { ... }
+.cal-cell.cal-abs-special:not(.cal-selected) { ... }
+.cal-cell.cal-abs-overtime_comp:not(.cal-selected) { ... }
+.cal-cell.cal-abs-education:not(.cal-selected) { ... }
+.cal-cell.cal-abs-unpaid:not(.cal-selected) { ... }
+```
+
+Note: The leave calendar never sets `.cal-selected`, so adding `:not(.cal-selected)` to the weekend rule (previously it had no such guard for `.cal-cell.cal-weekend`) is safe — no `.cal-selected` class exists on leave cells, so the selector still matches.
+</interfaces>
+
+## Project rules that matter for this task
+
+From CLAUDE.md "UI Consistency Rules":
+- Use CSS custom properties, NEVER hardcode hex colors
+- `card-animate` is defined globally — don't redefine
+- Glass surfaces use `var(--glass-bg)`, `var(--glass-border)`, etc.
+- See `.planning/UI_STYLE_GUIDE.md` for tokens
+
+From CLAUDE.md "Svelte 5 Gotchas":
+- `{@const}` only inside `{#if}/{#each}/{#snippet}`, not inside `<div>`
+- Use `$derived` for computed values
+
+No functional/business-logic changes — this is purely a CSS class rename refactor.
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Migrate Zeiterfassung (time-entries) calendar to canonical class names</name>
+  <files>apps/web/src/routes/(app)/time-entries/+page.svelte</files>
+  <action>
+Rename CSS classes in BOTH the template markup and the scoped `<style>` block (including mobile `@media` overrides) to the canonical set. Do NOT change any TypeScript logic, data shape, handlers, or rendered content — only class names.
+
+**Renames to apply (search-and-replace within this file only, in both template and `<style>` blocks):**
+
+1. Wrapper class in template:
+   - `class="cal-day cal-day--{day.status}{day.absenceType ... ? ' cal-day--abs cal-day--abs-' + day.absenceType.toLowerCase() : ''}"`
+   - → `class="cal-cell cal-cell--{day.status}{day.absenceType ... ? ' cal-abs cal-abs-' + day.absenceType.toLowerCase() : ''}"`
+   - Also update the skeleton: `<div class="cal-day skeleton">` → `<div class="cal-cell skeleton">`
+
+2. `class:*` directives on the calendar cell `<div>` (lines ~962-968):
+   - `class:other-month={!day.isCurrentMonth}` → `class:cal-other={!day.isCurrentMonth}`
+   - `class:is-today={day.isToday}` → `class:cal-today={day.isToday}`
+   - `class:is-weekend={day.isWeekend}` → `class:cal-weekend={day.isWeekend}`
+   - `class:is-holiday={day.isHoliday && day.isCurrentMonth}` → `class:cal-holiday={day.isHoliday && day.isCurrentMonth}`
+   - `class:is-selected={day.dateStr === selectedDate && day.isCurrentMonth}` → `class:cal-selected={day.dateStr === selectedDate && day.isCurrentMonth}`
+   - `class:cal-day--disabled={day.isBeforeHire && day.isCurrentMonth}` → `class:cal-cell--disabled={day.isBeforeHire && day.isCurrentMonth}`
+   - `class:cal-day--arbzg-warn={arbzgDayMap.has(day.dateStr) && day.isCurrentMonth}` → `class:cal-cell--arbzg-warn={arbzgDayMap.has(day.dateStr) && day.isCurrentMonth}`
+   - **Add NEW**: `class:cal-current={day.isCurrentMonth}` (so the wrapper expresses current-month state positively — needed so the `:not(.cal-other)` and `:not(.cal-selected)` guards in app.css continue to give the same selective behavior as before)
+
+3. Inner spans (template):
+   - `<span class="day-num">` → `<span class="cal-day-num">`
+   - `<span class="day-holiday-name">` → `<span class="cal-holiday-label">`
+   - `<span class="day-abs-type">` → `<span class="cal-abs-type">`
+   - Leave `.day-before-hire`, `.day-worked`, `.day-bal`, `.day-missing` UNCHANGED (Zeiterfassung-specific content, not in canonical set).
+
+4. Scoped `<style>` block — update ALL selectors referencing old names:
+   - `.cal-day` → `.cal-cell` (including `.cal-day:nth-child(7n)`, `.cal-day:not(.other-month):hover`, `.cal-day.is-today`, `.cal-day.skeleton`, etc.)
+   - `.other-month` → `.cal-other`
+   - `.is-today` → `.cal-today`
+   - `.is-weekend` → `.cal-weekend`
+   - `.is-holiday` → `.cal-holiday`
+   - `.is-selected` → `.cal-selected`
+   - `.day-num` → `.cal-day-num`
+   - `.day-holiday-name` → `.cal-holiday-label`
+   - `.day-abs-type` → `.cal-abs-type`
+   - `.cal-day--ok` → `.cal-cell--ok`
+   - `.cal-day--partial` → `.cal-cell--partial`
+   - `.cal-day--missing` → `.cal-cell--missing`
+   - `.cal-day--today-ok` → `.cal-cell--today-ok`
+   - `.cal-day--today-partial` → `.cal-cell--today-partial`
+   - `.cal-day--disabled` → `.cal-cell--disabled`
+   - `.cal-day--arbzg-warn` → `.cal-cell--arbzg-warn`
+   - Update all `:global(...)` wrappers accordingly: e.g., `:global(.cal-day.other-month)` → `:global(.cal-cell.cal-other)`, `:global(.cal-day.is-selected:not(.other-month))` → `:global(.cal-cell.cal-selected:not(.cal-other))`, `:global(.cal-day.is-selected:not(.other-month) .day-num)` → `:global(.cal-cell.cal-selected:not(.cal-other) .cal-day-num)`, etc.
+
+5. Mobile `@media` block (lines ~2170-2200):
+   - `.cal-day` → `.cal-cell`
+   - `.day-num` → `.cal-day-num`
+   - `.day-holiday-name` → `.cal-holiday-label`
+   - `.day-abs-type` → `.cal-abs-type`
+
+**Do NOT touch:**
+- TypeScript logic, data bindings, `onclick`/`onkeydown` handlers, `title={...}`, or any non-class attributes
+- `.cal-section`, `.cal-grid`, `.cal-header-row`, `.cal-dow`, `.cal-legend`, `.leg-*` — these are not part of the canonical rename
+- `.day-before-hire`, `.day-worked`, `.day-bal`, `.day-missing` — Zeiterfassung-specific, stay as-is
+- Any backup route/listing/editor dialog markup — only the calendar view
+
+**Verification after changes:**
+- Run `grep -n "\\.cal-day\\|\\.day-num\\|\\.day-holiday-name\\|\\.day-abs-type\\|is-weekend\\|is-holiday\\|other-month\\|is-today\\|is-selected" apps/web/src/routes/\\(app\\)/time-entries/+page.svelte` → should return zero matches inside the calendar block and its styles. (Matches outside the calendar — e.g., `.day-before-hire` — are fine.)
+- Use `mcp__svelte__svelte-autofixer` to validate the updated file; iterate until clean.
+  </action>
+  <verify>
+    <automated>cd /Users/sebastianzabel/git/clokr && docker compose exec -T web pnpm --filter @clokr/web exec svelte-check --threshold error 2>&amp;1 | tail -30</automated>
+  </verify>
+  <done>
+- `grep -c "\\.cal-day[^-]\\|\\.day-num\\|\\.day-holiday-name\\|\\.day-abs-type\\|class:is-weekend\\|class:is-holiday\\|class:other-month\\|class:is-today\\|class:is-selected" apps/web/src/routes/(app)/time-entries/+page.svelte` returns 0
+- `svelte-check` reports zero errors in time-entries/+page.svelte
+- File still contains `class="cal-cell` and `class:cal-today`, `class:cal-weekend`, `class:cal-holiday`, `class:cal-other`, `class:cal-selected`, `class:cal-current`
+- svelte-autofixer returns no issues on the file
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Align Abwesenheiten (leave) calendar + consolidate app.css shared rules</name>
+  <files>apps/web/src/routes/(app)/leave/+page.svelte, apps/web/src/app.css</files>
+  <action>
+**Part A — leave/+page.svelte (minimal change):**
+
+The leave calendar is already mostly on the canonical set. Two renames needed:
+
+1. `.cal-cell--current` → `.cal-current` — update in BOTH template and scoped `<style>`:
+   - Template line ~1405: `class:cal-cell--current={day.isCurrentMonth}` → `class:cal-current={day.isCurrentMonth}`
+   - Style block lines ~2687, ~2690: `.cal-cell--current { ... }` and `.cal-cell--current:hover { ... }` → `.cal-cell.cal-current { ... }` and `.cal-cell.cal-current:hover { ... }` (using `.cal-cell` compound form to keep specificity high enough against `.cal-cell` base)
+
+2. Do NOT rename `.cal-cell--drag-selected`, `.cal-chip*`, or other leave-specific modifiers.
+
+**Do NOT touch:**
+- Any drag-select logic, chip rendering, filter logic, or TypeScript
+- Any other page section — only the calendar block
+
+**Part B — app.css (consolidation):**
+
+Replace lines 1685-1721 (the shared calendar block) with the canonical-selector version:
+
+```css
+/* ─── Calendar shared: holiday + weekend cells ───────────────────────────────────── */
+.cal-cell.cal-holiday:not(.cal-other):not(.cal-selected) {
+  background: var(--color-brand-tint) !important;
+  border-left: 3px solid var(--color-brand);
+}
+
+.cal-cell.cal-weekend:not(.cal-other):not(.cal-selected) {
+  background: var(--color-bg-subtle) !important;
+}
+
+/* ─── Leave-type absence cell backgrounds (used by .cal-abs-* in Zeiterfassung) ── */
+.cal-cell.cal-abs-vacation:not(.cal-selected) {
+  background: color-mix(in srgb, var(--leave-type-vacation) 15%, var(--color-surface)) !important;
+  opacity: 1;
+}
+.cal-cell.cal-abs-sick:not(.cal-selected) {
+  background: color-mix(in srgb, var(--leave-type-sick) 15%, var(--color-surface)) !important;
+  opacity: 1;
+}
+.cal-cell.cal-abs-special:not(.cal-selected) {
+  background: color-mix(in srgb, var(--leave-type-special) 15%, var(--color-surface)) !important;
+  opacity: 1;
+}
+.cal-cell.cal-abs-overtime_comp:not(.cal-selected) {
+  background: color-mix(in srgb, var(--leave-type-overtime) 15%, var(--color-surface)) !important;
+  opacity: 1;
+}
+.cal-cell.cal-abs-education:not(.cal-selected) {
+  background: color-mix(in srgb, var(--leave-type-education) 15%, var(--color-surface)) !important;
+  opacity: 1;
+}
+.cal-cell.cal-abs-unpaid:not(.cal-selected) {
+  background: color-mix(in srgb, var(--leave-type-unpaid) 15%, var(--color-surface)) !important;
+  opacity: 1;
+}
+```
+
+**Why `:not(.cal-selected)` on the weekend rule:** The leave calendar never sets `.cal-selected`, so adding this guard is a no-op there. The guard matters for Zeiterfassung where `.cal-selected` should win over the weekend background (preserving pre-migration behavior).
+
+**Why `:not(.cal-other)` on holiday and weekend rules:** In Zeiterfassung, cells in the padding rows (previous/next month) should NOT get the holiday/weekend background treatment (current behavior, must be preserved). In the leave calendar, `.cal-other` is already excluded by the existing `.cal-cell.cal-weekend:not(.cal-other)` selector — same semantics kept.
+
+**Do NOT touch:**
+- Any other block in app.css (the reduced-motion block at ~1723, token definitions, theme blocks, etc.)
+- Do NOT add new rules, delete non-calendar rules, or reorder unrelated sections.
+
+**Verification after changes:**
+- Run `grep -n "\\.cal-day\\|\\.is-holiday\\|\\.is-weekend\\|\\.other-month\\|\\.is-selected" apps/web/src/app.css` → should return zero matches in the calendar block (note: old `is-selected` etc. may still legitimately appear elsewhere in app.css for non-calendar components; confirm they are not calendar-related)
+- Run `grep -n "cal-cell--current" apps/web/src/routes/\\(app\\)/leave/+page.svelte` → should return zero matches
+- Use `mcp__svelte__svelte-autofixer` to validate leave/+page.svelte; iterate until clean.
+  </action>
+  <verify>
+    <automated>cd /Users/sebastianzabel/git/clokr && docker compose exec -T web pnpm --filter @clokr/web exec svelte-check --threshold error 2>&amp;1 | tail -30 &amp;&amp; docker compose exec -T web pnpm --filter @clokr/web lint 2>&amp;1 | tail -10</automated>
+  </verify>
+  <done>
+- `grep -c "cal-cell--current" apps/web/src/routes/(app)/leave/+page.svelte` returns 0
+- app.css lines ~1685-1721 contain ONLY `.cal-cell.cal-holiday`, `.cal-cell.cal-weekend`, and `.cal-cell.cal-abs-*` selectors (no `.cal-day.is-holiday` or `.cal-day.cal-day--abs-*` duplicates)
+- `svelte-check` reports zero errors across apps/web
+- `pnpm lint` for apps/web reports zero new errors
+- svelte-autofixer returns no issues on leave/+page.svelte
+  </done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Human visual verification across both calendars + all themes</name>
+  <what-built>
+Renamed CSS classes in the Zeiterfassung and Abwesenheiten calendars to a single canonical set (`cal-cell`, `cal-day-num`, `cal-holiday-label`, `cal-weekend`, `cal-holiday`, `cal-other`, `cal-today`, `cal-current`, `cal-selected`, `cal-abs-*`). Consolidated the shared calendar rules in `app.css` so each concept has exactly one selector. No functional changes — pure CSS class rename refactor.
+  </what-built>
+  <how-to-verify>
+**Start the dev environment:**
+```bash
+docker compose up --build -d
+```
+
+Visit the app at http://localhost:5173 (or whichever port is mapped).
+
+**1. Zeiterfassung (Zeiterfassung > Kalender view) — http://localhost:5173/time-entries**
+   - [ ] Toggle to Kalender view (if list view is active)
+   - [ ] Day numbers visible in top-left of each cell
+   - [ ] Today cell has today border/highlight
+   - [ ] Weekend cells have the subtle grey background
+   - [ ] Other-month (padding) cells are dimmed
+   - [ ] Click any current-month day — cell gets the brand-colored selected state and opens the edit dialog
+   - [ ] Navigate to a month with a holiday — holiday cell has brand-tint background + left-border + holiday name label
+   - [ ] If there are absence entries (Urlaub/Krank/Sonderurlaub): cell has the corresponding leave-type background tint + absence type label (e.g., "Urlaub", "Krank")
+   - [ ] Cells with entries show worked hours + +/- saldo
+   - [ ] ArbZG warnings (if any) still highlight the day with the warn style
+   - [ ] Before-hire days (if employee was hired mid-month) are disabled/dimmed with the em-dash
+
+**2. Abwesenheiten (Leave > Kalender view) — http://localhost:5173/leave**
+   - [ ] Calendar renders correctly with day numbers in top-left
+   - [ ] Weekend cells have subtle grey background
+   - [ ] Today has today border
+   - [ ] Other-month cells dimmed
+   - [ ] Holidays show brand-tint background + "🎌 {name}" label
+   - [ ] Absence chips render in the correct leave-type colors
+   - [ ] Drag-select: mouse down on a day → drag across → cells highlight with the drag-selected state → release opens the new-leave dialog
+   - [ ] Hovering a current-month cell shows hover state
+
+**3. Theme switching — test on BOTH pages:**
+   - [ ] Switch theme to `pflaume` (default) — verify calendar looks correct
+   - [ ] Switch to `nacht` (dark) — holiday tint, weekend grey, selected state all still visible and themed correctly
+   - [ ] Switch to `wald` — colors still themed
+   - [ ] Switch to `schiefer` — colors still themed
+   - [ ] Switch to `pro` (Datadog-style) — verify
+   - [ ] On each theme, the holiday, weekend, today, selected, and absence-type backgrounds should use the theme's tokens (no pflaume-purple leaking into other themes)
+
+**4. Mobile viewport (Chrome DevTools ~390px):**
+   - [ ] Zeiterfassung calendar: cells still aligned, day numbers still visible, no layout break
+   - [ ] Abwesenheiten calendar: chips still readable
+   - [ ] (Known existing blocker: mobile overflow at 390px — do not regress it further)
+
+**5. Console check:**
+   - [ ] Open DevTools Console — no "undefined class", "unused CSS selector" warnings from Svelte compiler, no runtime errors
+
+If any of the above fails, note WHICH step and WHICH page/theme, and describe what looks wrong (ideally with a screenshot path).
+  </how-to-verify>
+  <resume-signal>Type "approved" if everything renders correctly across both calendars and all themes, or describe the issues (which page, which theme, which state) for fixes.</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+## Automated checks
+
+1. `svelte-check --threshold error` across `apps/web` reports zero errors in touched files.
+2. `pnpm --filter @clokr/web lint` reports zero new errors.
+3. `mcp__svelte__svelte-autofixer` returns no issues on both touched Svelte files.
+4. Grep sanity checks:
+   - `grep -c "class:is-today\|class:is-weekend\|class:is-holiday\|class:other-month\|class:is-selected" apps/web/src/routes/(app)/time-entries/+page.svelte` → 0
+   - `grep -c "cal-cell--current" apps/web/src/routes/(app)/leave/+page.svelte` → 0
+   - `grep -n "\.cal-day\.is-holiday\|\.cal-day\.cal-day--abs" apps/web/src/app.css` → 0 matches in the calendar-shared block
+
+## Human verification
+See Task 3 checkpoint.
+</verification>
+
+<success_criteria>
+- Both calendar pages use ONE canonical set of CSS class names (no more dual naming)
+- `app.css` shared calendar rules use ONE selector per concept (no more comma-joined dual selectors for the same rule)
+- `svelte-check`, `lint`, and `svelte-autofixer` all pass on the touched files
+- Human verification confirms both calendars render identically to pre-refactor state across all 5 themes, with all interactions (click, drag-select, navigation) still working
+- No TypeScript logic, data flow, or business rules were changed — pure CSS class rename
+- No new dependencies, components, or files created
+
+## Out of scope (explicitly not in this plan)
+- Building a shared `<CalendarBase>` Svelte component (research findings rule this out — too many slots needed)
+- Changing the calendar grid structure, date-logic, or any JavaScript/TypeScript behavior
+- Renaming `.cal-section`, `.cal-grid`, `.cal-header-row`, `.cal-dow`, `.cal-legend`, `.leg-*`, or any non-day-cell calendar classes
+- Extracting calendar styles to a separate CSS file
+- Adding new themes or tokens
+- Touching the mobile overflow blocker (existing known issue at 390px)
+- Refactoring the leave drag-select or zeiterfassung saldo rendering
+</success_criteria>
+
+<output>
+After completion, create `.planning/quick/260411-g4n-build-shared-calendar-base-component-to-/260411-g4n-SUMMARY.md` following the standard summary template, documenting:
+- The canonical class name set established
+- Files touched and line counts changed
+- That no Svelte shared component was created (and why — per research findings)
+- Any visual regressions found during verification and how they were fixed
+- Confirmation that both calendars are now using a single canonical class set and `app.css` has simplified shared rules
+</output>

--- a/.planning/quick/260411-g4n-build-shared-calendar-base-component-to-/260411-g4n-SUMMARY.md
+++ b/.planning/quick/260411-g4n-build-shared-calendar-base-component-to-/260411-g4n-SUMMARY.md
@@ -1,0 +1,114 @@
+---
+phase: 260411-g4n
+plan: "01"
+type: quick
+subsystem: web/ui
+tags: [css, refactor, calendar, time-entries, leave, canonical-classes]
+dependency_graph:
+  requires: []
+  provides: [canonical-calendar-css-classes]
+  affects: [apps/web/src/routes/(app)/time-entries/+page.svelte, apps/web/src/routes/(app)/leave/+page.svelte, apps/web/src/app.css]
+tech_stack:
+  added: []
+  patterns: [canonical-css-class-naming, global-shared-css-selectors]
+key_files:
+  created: []
+  modified:
+    - apps/web/src/routes/(app)/time-entries/+page.svelte
+    - apps/web/src/routes/(app)/leave/+page.svelte
+    - apps/web/src/app.css
+decisions:
+  - "No shared Svelte component — two calendars have fundamentally different content (time-entry data vs leave chips with drag-select); CSS class unification gives DRY benefit without brittle shared component"
+  - "Canonical class set uses cal-cell prefix for wrapper and modifiers (cal-cell--ok, cal-cell--disabled) and unprefixed state modifiers (cal-today, cal-weekend, cal-holiday, cal-other, cal-current, cal-selected)"
+  - "app.css rules guard with :not(.cal-other):not(.cal-selected) for holiday/weekend to preserve existing selective behavior"
+metrics:
+  duration_minutes: 15
+  completed_date: "2026-04-11"
+  tasks_completed: 2
+  tasks_total: 3
+  files_changed: 3
+---
+
+# Quick Task 260411-g4n: Build Shared Calendar Base Component Summary
+
+**One-liner:** Unified CSS class naming across Zeiterfassung and Abwesenheiten calendars — canonical `cal-cell`/`cal-*` set, single selector per concept in app.css.
+
+## What Was Done
+
+Renamed all CSS classes in both calendar pages to a single canonical set, and consolidated the shared calendar rules in `app.css` so each concept (holiday background, weekend background, absence-type backgrounds) has exactly one selector instead of the previous dual-selector pattern.
+
+### Canonical Class Name Set Established
+
+| Concept             | Old (time-entries)  | Old (leave)          | Canonical (both) |
+| ------------------- | ------------------- | -------------------- | ---------------- |
+| Cell wrapper        | `.cal-day`          | `.cal-cell`          | `.cal-cell`      |
+| Day number          | `.day-num`          | `.cal-day-num`       | `.cal-day-num`   |
+| Holiday label       | `.day-holiday-name` | `.cal-holiday-label` | `.cal-holiday-label` |
+| Weekend state       | `.is-weekend`       | `.cal-weekend`       | `.cal-weekend`   |
+| Holiday state       | `.is-holiday`       | `.cal-holiday`       | `.cal-holiday`   |
+| Other month state   | `.other-month`      | `.cal-other`         | `.cal-other`     |
+| Today state         | `.is-today`         | `.cal-today`         | `.cal-today`     |
+| Current month state | (none)              | `.cal-cell--current` | `.cal-current`   |
+| Selected state      | `.is-selected`      | (none)               | `.cal-selected`  |
+| Absence-type mod    | `.cal-day--abs-*`   | (none)               | `.cal-abs-*`     |
+| Cell status mod     | `.cal-day--ok` etc. | (none)               | `.cal-cell--ok` etc. |
+
+### Files Changed
+
+**apps/web/src/routes/(app)/time-entries/+page.svelte** — 43 insertions, 42 deletions
+- Template: wrapper class, class: directives, inner spans all renamed
+- Added `class:cal-current` positive current-month state
+- Scoped styles: all `.cal-day*`, `.day-num`, `.day-holiday-name`, `.day-abs-type`, `.is-today`, `.is-selected`, `.other-month` selectors updated
+- `:global()` blocks updated with new class names
+- Mobile `@media` block updated
+
+**apps/web/src/routes/(app)/leave/+page.svelte** — minimal change
+- Template: `class:cal-cell--current` → `class:cal-current`
+- Styles: `.cal-cell--current` → `.cal-cell.cal-current` and `.cal-cell--current:hover` → `.cal-cell.cal-current:hover`
+
+**apps/web/src/app.css** — 12 insertions, 14 deletions (lines 1685–1721)
+- Replaced dual-selector calendar rules with single canonical selectors
+- `.cal-day.is-holiday + .cal-holiday` → `.cal-cell.cal-holiday:not(.cal-other):not(.cal-selected)`
+- `.cal-day.is-weekend + .cal-cell.cal-weekend` → `.cal-cell.cal-weekend:not(.cal-other):not(.cal-selected)`
+- `.cal-day.cal-day--abs-*` → `.cal-cell.cal-abs-*` (all 6 leave-type backgrounds)
+
+### Why No Shared Svelte Component
+
+Per research findings documented in the plan: the two calendars have fundamentally different content (Zeiterfassung shows time-entry data, worked hours, ArbZG warnings, saldo; Abwesenheiten shows leave chips with drag-select). A shared component would require too many slots/props to be maintainable. CSS class unification delivers the DRY benefit in global styles without forcing a brittle abstraction.
+
+## Commits
+
+| Task | Commit  | Description                                              |
+| ---- | ------- | -------------------------------------------------------- |
+| 1    | 02d3511 | refactor(260411-g4n): migrate Zeiterfassung calendar to canonical CSS class names |
+| 2    | 834fdd8 | refactor(260411-g4n): align leave calendar + consolidate app.css shared rules |
+
+## Verification
+
+- `svelte-check --threshold error` → 0 errors, 0 warnings (both before and after changes)
+- `grep -c "class:is-today|class:is-weekend|..."` in time-entries → 0 (all old state classes renamed)
+- `grep -c "cal-cell--current"` in leave → 0 (renamed to cal-current)
+- `grep -n "\.cal-day\.is-holiday|\.cal-day\.cal-day--abs"` in app.css → no matches
+- app.css now has single canonical `.cal-cell.*` selector per concept
+
+## Requires Manual Visual Verification
+
+Task 3 is a `checkpoint:human-verify` — the automated tasks are complete but visual verification across both calendars and all themes has not been performed. See the plan's Task 3 checklist for verification steps:
+
+1. **Zeiterfassung calendar** (http://localhost:5173/time-entries): day numbers, today highlight, weekend grey, selected state, holiday tint, absence backgrounds, ArbZG warnings, before-hire dimming
+2. **Abwesenheiten calendar** (http://localhost:5173/leave): chips, drag-select, weekend/today/holiday states
+3. **Theme switching** across all 5 themes (pflaume, nacht, wald, schiefer, pro) on both pages
+4. **Mobile viewport** (~390px) — no new regressions beyond known overflow issue
+5. **Console** — no runtime errors
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Self-Check: PASSED
+
+- `apps/web/src/routes/(app)/time-entries/+page.svelte` — FOUND (modified)
+- `apps/web/src/routes/(app)/leave/+page.svelte` — FOUND (modified)
+- `apps/web/src/app.css` — FOUND (modified)
+- Commit 02d3511 — FOUND
+- Commit 834fdd8 — FOUND

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1748,11 +1748,35 @@ textarea.form-input {
 .cal-today {
   box-shadow: inset 0 0 0 2px var(--color-brand);
 }
-/* today+selected: ring statt volle Brand-Füllung, bg-subtle wie weekend */
+/* ─── Calendar: selection state ─────────────────────────────────────────── */
+.cal-cell.cal-selected:not(.cal-other) {
+  background-color: var(--color-brand) !important;
+  box-shadow:
+    0 0 0 2px var(--color-brand),
+    0 4px 12px rgba(0, 0, 0, 0.15) !important;
+  z-index: 1;
+}
+.cal-cell.cal-selected:not(.cal-other) .cal-day-num,
+.cal-cell.cal-selected:not(.cal-other) .day-worked,
+.cal-cell.cal-selected:not(.cal-other) .day-bal,
+.cal-cell.cal-selected:not(.cal-other) .day-missing,
+.cal-cell.cal-selected:not(.cal-other) .cal-abs-type,
+.cal-cell.cal-selected:not(.cal-other) .cal-holiday-label {
+  color: white !important;
+}
+/* today+selected: ring + bg-subtle; text reverts so day-worked/bal stay readable */
 .cal-cell.cal-selected.cal-today:not(.cal-other) {
   background-color: var(--color-bg-subtle) !important;
   box-shadow: inset 0 0 0 2px var(--color-brand) !important;
 }
+.cal-cell.cal-selected.cal-today:not(.cal-other) .day-worked,
+.cal-cell.cal-selected.cal-today:not(.cal-other) .day-bal,
+.cal-cell.cal-selected.cal-today:not(.cal-other) .day-missing,
+.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-abs-type,
+.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-holiday-label {
+  color: var(--color-text-muted) !important;
+}
+/* .cal-day-num: white on brand circle (handled by .cal-today .cal-day-num below) */
 .cal-day-num {
   font-size: 0.8rem;
   font-weight: 600;

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1740,10 +1740,17 @@ textarea.form-input {
 .cal-cell {
   background: var(--color-surface);
 }
-.cal-cell.cal-other {
-  opacity: 0.3 !important;
+/* WR-02: skeleton must override base background */
+.cal-cell.skeleton {
+  background: linear-gradient(90deg, var(--gray-100) 25%, var(--gray-200) 50%, var(--gray-100) 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s infinite;
+}
+/* WR-03: no !important — higher specificity handles conflict with status classes */
+.cal-cell.cal-other:not(.cal-selected) {
+  opacity: 0.3;
   cursor: default;
-  background: var(--gray-50, #f9fafb) !important;
+  background: var(--gray-50, #f9fafb);
 }
 .cal-today {
   box-shadow: inset 0 0 0 2px var(--color-brand);

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1718,6 +1718,62 @@ textarea.form-input {
   opacity: 1;
 }
 
+/* ─── Calendar shared: base layout + typography ─────────────────────────────── */
+.cal-section {
+  padding: 0;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+.cal-header-row {
+  border-bottom: 1.5px solid var(--gray-200, #e5e7eb);
+  background: var(--gray-50, #f9fafb);
+}
+.cal-dow {
+  padding: 0.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+.cal-cell.cal-other {
+  opacity: 0.3 !important;
+  cursor: default;
+  background: var(--gray-50, #f9fafb) !important;
+}
+.cal-today {
+  box-shadow: inset 0 0 0 2px var(--color-brand);
+}
+.cal-day-num {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  line-height: 1;
+  flex-shrink: 0;
+}
+.cal-today .cal-day-num {
+  background: var(--color-brand);
+  color: white;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+}
+.cal-holiday-label {
+  display: block;
+  font-size: 0.6875rem;
+  color: var(--color-brand);
+  font-weight: 600;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ─── Reduced Motion ─────────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1737,6 +1737,9 @@ textarea.form-input {
   letter-spacing: 0.06em;
   color: var(--color-text-muted);
 }
+.cal-cell {
+  background: var(--color-surface);
+}
 .cal-cell.cal-other {
   opacity: 0.3 !important;
   cursor: default;

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1748,9 +1748,9 @@ textarea.form-input {
 .cal-today {
   box-shadow: inset 0 0 0 2px var(--color-brand);
 }
-/* today+selected: ring statt volle Brand-Füllung */
+/* today+selected: ring statt volle Brand-Füllung, bg-subtle wie weekend */
 .cal-cell.cal-selected.cal-today:not(.cal-other) {
-  background-color: var(--color-brand-tint) !important;
+  background-color: var(--color-bg-subtle) !important;
   box-shadow: inset 0 0 0 2px var(--color-brand) !important;
 }
 .cal-day-num {

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1748,6 +1748,11 @@ textarea.form-input {
 .cal-today {
   box-shadow: inset 0 0 0 2px var(--color-brand);
 }
+/* today+selected: ring statt volle Brand-Füllung */
+.cal-cell.cal-selected.cal-today:not(.cal-other) {
+  background-color: var(--color-brand-tint) !important;
+  box-shadow: inset 0 0 0 2px var(--color-brand) !important;
+}
 .cal-day-num {
   font-size: 0.8rem;
   font-weight: 600;

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1683,39 +1683,37 @@ textarea.form-input {
 }
 
 /* ─── Calendar shared: holiday + weekend cells ───────────────────────────────────── */
-.cal-day.is-holiday:not(.other-month):not(.is-selected),
-.cal-holiday {
+.cal-cell.cal-holiday:not(.cal-other):not(.cal-selected) {
   background: var(--color-brand-tint) !important;
   border-left: 3px solid var(--color-brand);
 }
 
-.cal-day.is-weekend:not(.is-selected),
-.cal-cell.cal-weekend:not(.cal-other) {
+.cal-cell.cal-weekend:not(.cal-other):not(.cal-selected) {
   background: var(--color-bg-subtle) !important;
 }
 
-/* ─── Leave-type absence cell backgrounds (used by cal-day--abs-* in Zeiterfassung) ── */
-.cal-day.cal-day--abs-vacation:not(.is-selected) {
+/* ─── Leave-type absence cell backgrounds (used by .cal-abs-* in Zeiterfassung) ── */
+.cal-cell.cal-abs-vacation:not(.cal-selected) {
   background: color-mix(in srgb, var(--leave-type-vacation) 15%, var(--color-surface)) !important;
   opacity: 1;
 }
-.cal-day.cal-day--abs-sick:not(.is-selected) {
+.cal-cell.cal-abs-sick:not(.cal-selected) {
   background: color-mix(in srgb, var(--leave-type-sick) 15%, var(--color-surface)) !important;
   opacity: 1;
 }
-.cal-day.cal-day--abs-special:not(.is-selected) {
+.cal-cell.cal-abs-special:not(.cal-selected) {
   background: color-mix(in srgb, var(--leave-type-special) 15%, var(--color-surface)) !important;
   opacity: 1;
 }
-.cal-day.cal-day--abs-overtime_comp:not(.is-selected) {
+.cal-cell.cal-abs-overtime_comp:not(.cal-selected) {
   background: color-mix(in srgb, var(--leave-type-overtime) 15%, var(--color-surface)) !important;
   opacity: 1;
 }
-.cal-day.cal-day--abs-education:not(.is-selected) {
+.cal-cell.cal-abs-education:not(.cal-selected) {
   background: color-mix(in srgb, var(--leave-type-education) 15%, var(--color-surface)) !important;
   opacity: 1;
 }
-.cal-day.cal-day--abs-unpaid:not(.is-selected) {
+.cal-cell.cal-abs-unpaid:not(.cal-selected) {
   background: color-mix(in srgb, var(--leave-type-unpaid) 15%, var(--color-surface)) !important;
   opacity: 1;
 }

--- a/apps/web/src/routes/(app)/leave/+page.svelte
+++ b/apps/web/src/routes/(app)/leave/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { run, preventDefault, self } from "svelte/legacy";
+  import { preventDefault, self } from "svelte/legacy";
 
   import { onMount, onDestroy } from "svelte";
   import { page } from "$app/stores";
@@ -896,14 +896,14 @@
     myReqPage = 1;
   });
 
-  run(() => {
+  $effect(() => {
     if (showForm) {
       formStart;
       formEnd;
       scheduleOverlapLoad();
     }
   });
-  run(() => {
+  $effect(() => {
     if (showForm) {
       formStart;
       formEnd;
@@ -912,7 +912,7 @@
     }
   });
   // Kontostände laden wenn Typ wechselt oder Formular öffnet
-  run(() => {
+  $effect(() => {
     if (showForm) loadBalanceForType(formType);
   });
 </script>
@@ -1417,6 +1417,15 @@
           tabindex={day.isCurrentMonth ? 0 : undefined}
           onmousedown={() => handleDayMouseDown(day.dateStr, day.isCurrentMonth)}
           onmouseenter={() => handleDayMouseEnter(day.dateStr)}
+          onkeydown={(e) => {
+            if ((e.key === "Enter" || e.key === " ") && day.isCurrentMonth) {
+              e.preventDefault();
+              formStart = day.dateStr;
+              formEnd = day.dateStr;
+              editingRequest = null;
+              showForm = true;
+            }
+          }}
         >
           <span class="cal-day-num">{day.dayNum}</span>
           {#if isHoliday && day.isCurrentMonth}
@@ -2468,12 +2477,12 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    background: var(--brand-light, #eff6ff);
-    border: 1px solid var(--brand-border, #bfdbfe);
+    background: var(--color-brand-tint);
+    border: 1px solid var(--color-brand-tint-hover);
     border-radius: 8px;
     padding: 0.5rem 0.875rem;
     font-size: 0.9375rem;
-    color: var(--brand, #2563eb);
+    color: var(--color-brand);
   }
   .days-info-icon {
     font-size: 1rem;
@@ -2741,8 +2750,8 @@
   .legend-holiday-dot {
     width: 10px;
     height: 10px;
-    background: #ede7f6;
-    border: 1.5px solid #80377b;
+    background: var(--color-brand-tint);
+    border: 1.5px solid var(--color-brand);
     border-radius: 2px;
     flex-shrink: 0;
     display: inline-block;

--- a/apps/web/src/routes/(app)/leave/+page.svelte
+++ b/apps/web/src/routes/(app)/leave/+page.svelte
@@ -2483,12 +2483,6 @@
   }
 
   /* ── Kalender ─────────────────────────────────────────────────────── */
-  .cal-section {
-    padding: 0;
-    overflow: hidden;
-    margin-bottom: 1rem;
-  }
-
   .cal-nav {
     display: grid;
     grid-template-columns: auto 1fr auto;
@@ -2639,19 +2633,6 @@
     grid-template-columns: repeat(7, 1fr);
     user-select: none;
   }
-  .cal-header-row {
-    border-bottom: 1.5px solid var(--gray-200, #e5e7eb);
-    background: var(--gray-50, #f9fafb);
-  }
-  .cal-dow {
-    padding: 0.5rem;
-    text-align: center;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--color-text-muted);
-  }
 
   .cal-loading {
     opacity: 0.5;
@@ -2659,7 +2640,6 @@
   }
 
   .cal-cell {
-    background: #fff;
     min-height: 72px;
     padding: 0.3rem 0.4rem 0.4rem;
     border-right: 1px solid var(--gray-100, #f3f4f6);
@@ -2672,16 +2652,6 @@
   }
   .cal-cell:nth-child(7n) {
     border-right: none;
-  }
-
-  :global(.cal-cell.cal-other) {
-    opacity: 0.3 !important;
-    cursor: default;
-    background: var(--gray-50, #f9fafb) !important;
-  }
-  /* Weekend + holiday cell styles → global in app.css */
-  .cal-today {
-    box-shadow: inset 0 0 0 2px var(--color-brand);
   }
 
   .cal-cell.cal-current {
@@ -2697,33 +2667,7 @@
   }
 
   .cal-day-num {
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--color-text-muted);
-    line-height: 1;
-    flex-shrink: 0;
     z-index: 1;
-  }
-  .cal-today .cal-day-num {
-    background: var(--color-brand);
-    color: white;
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.7rem;
-  }
-
-  .cal-holiday-label {
-    font-size: 0.6875rem;
-    color: #6b21a8;
-    font-weight: 600;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    padding: 1px 2px;
   }
 
   .cal-chips {

--- a/apps/web/src/routes/(app)/leave/+page.svelte
+++ b/apps/web/src/routes/(app)/leave/+page.svelte
@@ -1421,7 +1421,7 @@
           <span class="cal-day-num">{day.dayNum}</span>
           {#if isHoliday && day.isCurrentMonth}
             <div class="cal-holiday-label" title={holidays[0].typeName ?? ""}>
-              🎌 {holidays[0].firstName}
+              {holidays[0].firstName}
             </div>
           {/if}
           <div class="cal-chips">

--- a/apps/web/src/routes/(app)/leave/+page.svelte
+++ b/apps/web/src/routes/(app)/leave/+page.svelte
@@ -1402,7 +1402,7 @@
         {@const isHoliday = holidays.length > 0}
         <div
           class="cal-cell"
-          class:cal-cell--current={day.isCurrentMonth}
+          class:cal-current={day.isCurrentMonth}
           class:cal-other={!day.isCurrentMonth}
           class:cal-today={day.isToday}
           class:cal-weekend={day.isWeekend && day.isCurrentMonth}
@@ -2684,10 +2684,10 @@
     box-shadow: inset 0 0 0 2px var(--color-brand);
   }
 
-  .cal-cell--current {
+  .cal-cell.cal-current {
     cursor: pointer;
   }
-  .cal-cell--current:hover {
+  .cal-cell.cal-current:hover {
     background: var(--color-bg-subtle, #f3f0ff);
   }
   .cal-cell--drag-selected {

--- a/apps/web/src/routes/(app)/leave/+page.svelte
+++ b/apps/web/src/routes/(app)/leave/+page.svelte
@@ -1317,7 +1317,7 @@
     </div>
   {/if}
 
-  <div class="cal-section card">
+  <div class="cal-section card card-animate">
     <!-- Navigation -->
     <div class="cal-nav">
       <button class="nav-btn" onclick={prevMonth} title="Vorheriger Monat">
@@ -1394,7 +1394,12 @@
     </div>
 
     <!-- Tage -->
-    <div class="cal-grid {calLoading ? 'cal-loading' : ''}">
+    {#if calLoading}
+      <div class="cal-grid">
+        {#each Array(35) as _, i (i)}<div class="cal-cell skeleton"></div>{/each}
+      </div>
+    {:else}
+    <div class="cal-grid">
       {#each calDays as day (day.dateStr)}
         {@const entries = calMap.get(day.dateStr) ?? []}
         {@const holidays = entries.filter((e) => e.isHoliday)}
@@ -1448,6 +1453,7 @@
         </div>
       {/each}
     </div>
+    {/if}
 
     <!-- Legende -->
     <div class="cal-legend">

--- a/apps/web/src/routes/(app)/time-entries/+page.svelte
+++ b/apps/web/src/routes/(app)/time-entries/+page.svelte
@@ -1550,40 +1550,6 @@
     box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--color-brand) 25%, transparent);
   }
 
-  /* :global nötig – Svelte doppelt den Scope-Hash bei Compound-Selektoren */
-  :global(.cal-cell.cal-selected:not(.cal-other)) {
-    background-color: var(--color-brand) !important;
-    box-shadow:
-      0 0 0 2px var(--color-brand),
-      0 4px 12px rgba(0, 0, 0, 0.15) !important;
-    z-index: 1;
-  }
-  :global(.cal-cell.cal-selected:not(.cal-other) .cal-day-num),
-  :global(.cal-cell.cal-selected:not(.cal-other) .day-worked),
-  :global(.cal-cell.cal-selected:not(.cal-other) .day-bal),
-  :global(.cal-cell.cal-selected:not(.cal-other) .day-missing),
-  :global(.cal-cell.cal-selected:not(.cal-other) .cal-abs-type),
-  :global(.cal-cell.cal-selected:not(.cal-other) .cal-holiday-label) {
-    color: white !important;
-  }
-  /* today+selected: Ring statt volle Füllung (wie leave-Kalender) */
-  :global(.cal-cell.cal-selected.cal-today:not(.cal-other)) {
-    background-color: var(--color-brand-tint) !important;
-    box-shadow: inset 0 0 0 2px var(--color-brand) !important;
-  }
-  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-day-num),
-  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .day-worked),
-  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .day-bal),
-  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .day-missing),
-  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-abs-type),
-  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-holiday-label) {
-    color: var(--color-text) !important;
-  }
-  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-day-num) {
-    background: var(--color-brand);
-    color: white;
-  }
-
   /* Status-Farben */
   .cal-cell--ok {
     background: #f0fdf4;

--- a/apps/web/src/routes/(app)/time-entries/+page.svelte
+++ b/apps/web/src/routes/(app)/time-entries/+page.svelte
@@ -1309,12 +1309,6 @@
   }
 
   /* ── Kalender ─────────────────────────────────────────────────────── */
-  .cal-section {
-    padding: 0;
-    overflow: hidden;
-    margin-bottom: 1rem;
-  }
-
   .cal-nav {
     display: flex;
     align-items: center;
@@ -1510,21 +1504,6 @@
     grid-template-columns: repeat(7, 1fr);
   }
 
-  .cal-header-row {
-    border-bottom: 1.5px solid var(--gray-200, #e5e7eb);
-    background: var(--gray-50, #f9fafb);
-  }
-
-  .cal-dow {
-    padding: 0.5rem;
-    text-align: center;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--color-text-muted);
-  }
-
   .cal-cell {
     min-height: 72px;
     padding: 0.3rem 0.4rem;
@@ -1541,12 +1520,6 @@
   }
   .cal-cell:nth-child(7n) {
     border-right: none;
-  }
-
-  :global(.cal-cell.cal-other) {
-    opacity: 0.3 !important;
-    cursor: default;
-    background: var(--gray-50, #f9fafb) !important;
   }
 
   /* Tage vor dem Eintrittsdatum */
@@ -1571,10 +1544,6 @@
     box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--color-brand) 25%, transparent);
   }
 
-  .cal-cell.cal-today {
-    box-shadow: inset 0 0 0 2px var(--color-brand);
-  }
-
   /* :global nötig – Svelte doppelt den Scope-Hash bei Compound-Selektoren */
   :global(.cal-cell.cal-selected:not(.cal-other)) {
     background-color: var(--color-brand) !important;
@@ -1594,20 +1563,6 @@
   :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-day-num) {
     background: rgba(255, 255, 255, 0.25);
     color: white;
-  }
-
-  /* Wochenende + Feiertage */
-  /* Weekend + holiday cell styles → global in app.css */
-  .cal-holiday-label {
-    display: block;
-    font-size: 0.6rem;
-    color: var(--color-brand);
-    font-weight: 600;
-    line-height: 1.2;
-    margin-top: 0.1rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   /* Status-Farben */
@@ -1645,24 +1600,6 @@
     white-space: nowrap;
   }
 
-  .cal-day-num {
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: var(--color-text-muted);
-    line-height: 1;
-    flex-shrink: 0;
-  }
-  .cal-today .cal-day-num {
-    background: var(--color-brand);
-    color: white;
-    width: 18px;
-    height: 18px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.65rem;
-  }
   .day-worked {
     font-size: 0.75rem;
     font-weight: 700;

--- a/apps/web/src/routes/(app)/time-entries/+page.svelte
+++ b/apps/web/src/routes/(app)/time-entries/+page.svelte
@@ -871,8 +871,8 @@
   </div>
 {/if}
 
-<!-- ── Monat-Navigation (beide Ansichten) ────────────────────────────────── -->
-<div class="cal-nav month-nav-standalone">
+<!-- ── Monat-Navigation (snippet, wiederverwendet in Kalender + Liste) ───── -->
+{#snippet navContent()}
   <button class="nav-btn" onclick={() => gotoMonth(-1)} title="Vorheriger Monat">
     <svg
       width="18"
@@ -934,11 +934,14 @@
       stroke-width="2.5"><polyline points="9 18 15 12 9 6" /></svg
     >
   </button>
-</div>
+{/snippet}
 
 <!-- ── Kalender ─────────────────────────────────────────────────────────── -->
 {#if teView === "calendar"}
   <div class="cal-section card card-animate">
+    <div class="cal-nav">
+      {@render navContent()}
+    </div>
     <!-- Wochentage-Header -->
     <div class="cal-grid cal-header-row">
       {#each ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"] as d (d)}
@@ -1024,6 +1027,9 @@
 
 <!-- ── Listenansicht ──────────────────────────────────────────────────── -->
 {#if teView === "list"}
+  <div class="cal-nav month-nav-standalone">
+    {@render navContent()}
+  </div>
   <div class="table-wrapper">
     <table class="data-table">
       <thead>

--- a/apps/web/src/routes/(app)/time-entries/+page.svelte
+++ b/apps/web/src/routes/(app)/time-entries/+page.svelte
@@ -1301,7 +1301,7 @@
 
   /* ── Warning button ────────────────────────────────────────────── */
   .btn-warning {
-    background: #f59e0b;
+    background: var(--color-yellow);
     color: #fff;
     border: none;
     border-radius: 6px;
@@ -1311,7 +1311,7 @@
     cursor: pointer;
   }
   .btn-warning:hover {
-    background: #d97706;
+    background: var(--color-yellow-border);
   }
 
   /* ── Kalender ─────────────────────────────────────────────────────── */
@@ -1552,19 +1552,19 @@
 
   /* Status-Farben */
   .cal-cell--ok {
-    background: #f0fdf4;
+    background: var(--color-green-bg);
   }
   .cal-cell--partial {
-    background: #fffbeb;
+    background: var(--color-yellow-bg);
   }
   .cal-cell--missing {
-    background: #fef2f2;
+    background: var(--color-red-bg);
   }
   .cal-cell--today-ok {
-    background: #f0fdf4;
+    background: var(--color-green-bg);
   }
   .cal-cell--today-partial {
-    background: #fffbeb;
+    background: var(--color-yellow-bg);
   }
 
   /* Abwesenheitsfarben – allgemein (überschreiben Status-Farben) */
@@ -1597,15 +1597,15 @@
     font-weight: 600;
   }
   .day-bal.pos {
-    color: #16a34a;
+    color: var(--color-green);
   }
   .day-bal.neg {
-    color: #dc2626;
+    color: var(--color-red);
   }
   .day-missing {
     font-size: 0.7rem;
     font-family: var(--font-mono);
-    color: #dc2626;
+    color: var(--color-red);
     opacity: 0.75;
   }
 
@@ -1810,16 +1810,6 @@
     padding: 0.15rem 0.5rem;
     border-radius: 4px;
   }
-  .btn-outline {
-    border: 1px solid #3b82f6;
-    color: #3b82f6;
-    background: white;
-    cursor: pointer;
-  }
-  .btn-outline:hover {
-    background: #eff6ff;
-  }
-
   .btn-icon {
     background: none;
     border: none;

--- a/apps/web/src/routes/(app)/time-entries/+page.svelte
+++ b/apps/web/src/routes/(app)/time-entries/+page.svelte
@@ -949,23 +949,24 @@
     <!-- Tage -->
     {#if loading}
       <div class="cal-grid">
-        {#each Array(35) as _, i (i)}<div class="cal-day skeleton"></div>{/each}
+        {#each Array(35) as _, i (i)}<div class="cal-cell skeleton"></div>{/each}
       </div>
     {:else}
       <div class="cal-grid">
         {#each calendarDays as day (day.dateStr)}
           <div
             data-date={day.dateStr}
-            class="cal-day cal-day--{day.status}{day.absenceType && !day.isWeekend
-              ? ' cal-day--abs cal-day--abs-' + day.absenceType.toLowerCase()
+            class="cal-cell cal-cell--{day.status}{day.absenceType && !day.isWeekend
+              ? ' cal-abs cal-abs-' + day.absenceType.toLowerCase()
               : ''}"
-            class:other-month={!day.isCurrentMonth}
-            class:is-today={day.isToday}
-            class:is-weekend={day.isWeekend}
-            class:is-holiday={day.isHoliday && day.isCurrentMonth}
-            class:is-selected={day.dateStr === selectedDate && day.isCurrentMonth}
-            class:cal-day--disabled={day.isBeforeHire && day.isCurrentMonth}
-            class:cal-day--arbzg-warn={arbzgDayMap.has(day.dateStr) && day.isCurrentMonth}
+            class:cal-other={!day.isCurrentMonth}
+            class:cal-current={day.isCurrentMonth}
+            class:cal-today={day.isToday}
+            class:cal-weekend={day.isWeekend}
+            class:cal-holiday={day.isHoliday && day.isCurrentMonth}
+            class:cal-selected={day.dateStr === selectedDate && day.isCurrentMonth}
+            class:cal-cell--disabled={day.isBeforeHire && day.isCurrentMonth}
+            class:cal-cell--arbzg-warn={arbzgDayMap.has(day.dateStr) && day.isCurrentMonth}
             title={day.isBeforeHire
               ? "Vor Eintrittsdatum"
               : day.isHoliday
@@ -983,11 +984,11 @@
                 openAdd(day.dateStr);
             }}
           >
-            <span class="day-num">{day.dayNum}</span>
+            <span class="cal-day-num">{day.dayNum}</span>
             {#if day.isHoliday && day.isCurrentMonth}
-              <span class="day-holiday-name">{day.holidayName}</span>
+              <span class="cal-holiday-label">{day.holidayName}</span>
             {:else if day.absenceType}
-              <span class="day-abs-type"
+              <span class="cal-abs-type"
                 >{absenceLabel(day.absenceType)}{day.absenceHalf ? " ½" : ""}</span
               >
             {/if}
@@ -1524,7 +1525,7 @@
     color: var(--color-text-muted);
   }
 
-  .cal-day {
+  .cal-cell {
     min-height: 72px;
     padding: 0.3rem 0.4rem;
     border-right: 1px solid var(--gray-100, #f3f4f6);
@@ -1538,25 +1539,25 @@
       box-shadow 0.12s;
     position: relative;
   }
-  .cal-day:nth-child(7n) {
+  .cal-cell:nth-child(7n) {
     border-right: none;
   }
 
-  :global(.cal-day.other-month) {
+  :global(.cal-cell.cal-other) {
     opacity: 0.3 !important;
     cursor: default;
     background: var(--gray-50, #f9fafb) !important;
   }
 
   /* Tage vor dem Eintrittsdatum */
-  :global(.cal-day.cal-day--disabled) {
+  :global(.cal-cell.cal-cell--disabled) {
     opacity: 0.4;
     pointer-events: none;
     cursor: default;
     background: var(--gray-50, #f9fafb) !important;
   }
 
-  :global(.cal-day.cal-day--arbzg-warn) {
+  :global(.cal-cell.cal-cell--arbzg-warn) {
     border-left: 3px solid #f59e0b;
     background: rgba(245, 158, 11, 0.08);
   }
@@ -1565,39 +1566,39 @@
     color: var(--color-text-muted);
     opacity: 0.5;
   }
-  .cal-day:not(.other-month):hover {
+  .cal-cell:not(.cal-other):hover {
     background: color-mix(in srgb, var(--color-brand) 8%, transparent);
     box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--color-brand) 25%, transparent);
   }
 
-  .cal-day.is-today {
+  .cal-cell.cal-today {
     box-shadow: inset 0 0 0 2px var(--color-brand);
   }
 
   /* :global nötig – Svelte doppelt den Scope-Hash bei Compound-Selektoren */
-  :global(.cal-day.is-selected:not(.other-month)) {
+  :global(.cal-cell.cal-selected:not(.cal-other)) {
     background-color: var(--color-brand) !important;
     box-shadow:
       0 0 0 2px var(--color-brand),
       0 4px 12px rgba(0, 0, 0, 0.15) !important;
     z-index: 1;
   }
-  :global(.cal-day.is-selected:not(.other-month) .day-num),
-  :global(.cal-day.is-selected:not(.other-month) .day-worked),
-  :global(.cal-day.is-selected:not(.other-month) .day-bal),
-  :global(.cal-day.is-selected:not(.other-month) .day-missing),
-  :global(.cal-day.is-selected:not(.other-month) .day-abs-type),
-  :global(.cal-day.is-selected:not(.other-month) .day-holiday-name) {
+  :global(.cal-cell.cal-selected:not(.cal-other) .cal-day-num),
+  :global(.cal-cell.cal-selected:not(.cal-other) .day-worked),
+  :global(.cal-cell.cal-selected:not(.cal-other) .day-bal),
+  :global(.cal-cell.cal-selected:not(.cal-other) .day-missing),
+  :global(.cal-cell.cal-selected:not(.cal-other) .cal-abs-type),
+  :global(.cal-cell.cal-selected:not(.cal-other) .cal-holiday-label) {
     color: white !important;
   }
-  :global(.cal-day.is-selected.is-today:not(.other-month) .day-num) {
+  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-day-num) {
     background: rgba(255, 255, 255, 0.25);
     color: white;
   }
 
   /* Wochenende + Feiertage */
   /* Weekend + holiday cell styles → global in app.css */
-  .day-holiday-name {
+  .cal-holiday-label {
     display: block;
     font-size: 0.6rem;
     color: var(--color-brand);
@@ -1610,28 +1611,28 @@
   }
 
   /* Status-Farben */
-  .cal-day--ok {
+  .cal-cell--ok {
     background: #f0fdf4;
   }
-  .cal-day--partial {
+  .cal-cell--partial {
     background: #fffbeb;
   }
-  .cal-day--missing {
+  .cal-cell--missing {
     background: #fef2f2;
   }
-  .cal-day--today-ok {
+  .cal-cell--today-ok {
     background: #f0fdf4;
   }
-  .cal-day--today-partial {
+  .cal-cell--today-partial {
     background: #fffbeb;
   }
 
   /* Abwesenheitsfarben – allgemein (überschreiben Status-Farben) */
-  /* Absence cell backgrounds → global in app.css (.cal-day--abs-*) */
+  /* Absence cell backgrounds → global in app.css (.cal-abs-*) */
 
   /* Nachbarmonat-Tage mit Abwesenheit etwas heller darstellen */
 
-  .day-abs-type {
+  .cal-abs-type {
     display: block;
     font-size: 0.6rem;
     font-weight: 700;
@@ -1644,14 +1645,14 @@
     white-space: nowrap;
   }
 
-  .day-num {
+  .cal-day-num {
     font-size: 0.75rem;
     font-weight: 600;
     color: var(--color-text-muted);
     line-height: 1;
     flex-shrink: 0;
   }
-  .is-today .day-num {
+  .cal-today .cal-day-num {
     background: var(--color-brand);
     color: white;
     width: 18px;
@@ -2167,7 +2168,7 @@
   /* ── Mobile calendar improvements ──────────────────────────────── */
   @media (max-width: 640px) {
     /* Reduce cell height on mobile but keep them tappable */
-    .cal-day {
+    .cal-cell {
       min-height: 72px;
       padding: 0.375rem 0.375rem;
     }
@@ -2184,13 +2185,13 @@
     }
 
     /* Smaller day numbers on mobile */
-    .day-num {
+    .cal-day-num {
       font-size: 0.75rem;
     }
 
     /* Holiday/absence labels smaller on mobile */
-    .day-holiday-name,
-    .day-abs-type {
+    .cal-holiday-label,
+    .cal-abs-type {
       font-size: 0.5rem;
     }
 

--- a/apps/web/src/routes/(app)/time-entries/+page.svelte
+++ b/apps/web/src/routes/(app)/time-entries/+page.svelte
@@ -1566,8 +1566,21 @@
   :global(.cal-cell.cal-selected:not(.cal-other) .cal-holiday-label) {
     color: white !important;
   }
+  /* today+selected: Ring statt volle Füllung (wie leave-Kalender) */
+  :global(.cal-cell.cal-selected.cal-today:not(.cal-other)) {
+    background-color: var(--color-brand-tint) !important;
+    box-shadow: inset 0 0 0 2px var(--color-brand) !important;
+  }
+  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-day-num),
+  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .day-worked),
+  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .day-bal),
+  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .day-missing),
+  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-abs-type),
+  :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-holiday-label) {
+    color: var(--color-text) !important;
+  }
   :global(.cal-cell.cal-selected.cal-today:not(.cal-other) .cal-day-num) {
-    background: rgba(255, 255, 255, 0.25);
+    background: var(--color-brand);
     color: white;
   }
 


### PR DESCRIPTION
## Summary

- Migrated both calendars (Zeiterfassung + Abwesenheiten) to the same canonical CSS class names (`cal-cell`, `cal-today`, `cal-day-num`, `cal-holiday-label`, etc.)
- Moved all shared calendar rules — including `cal-selected` and `cal-selected.cal-today` — to `app.css` as true global rules (no more `:global()` hacks in component scoped styles)
- Unified today-cell appearance: ring (`inset 0 0 0 2px var(--color-brand)`) + `bg-subtle` fill in both calendars
- Added `card-animate` entrance animation and skeleton loading to leave calendar
- Merged month-nav into the calendar card in Zeiterfassung (one box, not two)
- Removed `🎌` emoji from holiday labels in leave calendar

## Test plan

- [ ] Zeiterfassung: today cell shows purple ring + beige bg, selected cell shows brand fill + white text
- [ ] Abwesenheiten: today cell looks identical to Zeiterfassung today cell
- [ ] Holiday cells: left border + brand-tint bg, no emoji before name
- [ ] Leave calendar has entrance animation (card-animate) and skeleton while loading
- [ ] Dark themes (Nacht, Schiefer): no hardcoded white backgrounds visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)