### PR TITLE
security: HSTS, CSP nonce, CORS wildcard guard, rate limit cleanup

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -130,7 +130,12 @@ export async function buildApp() {
     },
   );
 
-  await app.register(helmet, { contentSecurityPolicy: false });
+  await app.register(helmet, {
+    contentSecurityPolicy: false, // API is JSON-only; no HTML served (Swagger UI excluded)
+    hsts: config.NODE_ENV === "production"
+      ? { maxAge: 31536000, includeSubDomains: true, preload: false }
+      : false,
+  });
   await app.register(cors, {
     origin: config.CORS_ORIGIN,
     credentials: true,

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -11,7 +11,9 @@ const envSchema = z
     JWT_REFRESH_SECRET: z.string().min(32),
     JWT_EXPIRES_IN: z.string().default("15m"),
     JWT_REFRESH_EXPIRES_IN: z.string().default("7d"),
-    CORS_ORIGIN: z.string().default("http://localhost:5173"),
+    CORS_ORIGIN: z.string().default("http://localhost:5173").refine((v) => v !== "*", {
+      message: "CORS_ORIGIN must not be a wildcard (*) — set an explicit origin",
+    }),
     REDIS_URL: z.string().default("redis://localhost:6379"),
     APP_URL: z.string().default("http://localhost:5173"),
     POOL_MIN: z.coerce.number().default(2),

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { Role } from "@clokr/db";
 import { JwtPayload } from "../middleware/auth";
 import { validatePassword, loadPasswordPolicy } from "../utils/password-policy";
+import { config } from "../config";
 
 /** SHA-256 hash for tokens stored in DB (refresh tokens, reset tokens). */
 function hashToken(token: string): string {
@@ -36,10 +37,8 @@ const resetPasswordSchema = z.object({
 
 export async function authRoutes(app: FastifyInstance) {
   // POST /api/v1/auth/login
-  const isTest = process.env.NODE_ENV === "test";
-
   app.post("/login", {
-    config: { rateLimit: { max: isTest ? 1000 : 50, timeWindow: "1 minute" } },
+    config: { rateLimit: { max: config.NODE_ENV === "test" ? 1000 : 50, timeWindow: "1 minute" } },
     schema: {
       tags: ["Auth"],
       body: {

--- a/apps/web/src/app.d.ts
+++ b/apps/web/src/app.d.ts
@@ -1,1 +1,9 @@
 declare const __APP_VERSION__: string;
+
+declare global {
+  namespace App {
+    interface Locals {
+      nonce: string;
+    }
+  }
+}

--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import type { Handle, HandleServerError } from "@sveltejs/kit";
 
 const API_BACKEND = process.env.API_URL || "http://localhost:4000";
@@ -62,16 +63,27 @@ export const handle: Handle = async ({ event, resolve }) => {
     }
   }
 
-  // SSR page requests
-  const response = await resolve(event);
+  // SSR page requests — generate a per-request nonce for inline scripts
+  const nonce = randomBytes(16).toString("base64");
+  event.locals.nonce = nonce;
+
+  const response = await resolve(event, {
+    // Inject nonce into all <script> tags SvelteKit generates for hydration
+    transformPageChunk: ({ html }) => html.replace(/<script\b/g, `<script nonce="${nonce}"`),
+  });
+
+  // HSTS — only meaningful in production behind TLS
+  if (process.env.NODE_ENV === "production") {
+    response.headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  }
 
   // Content Security Policy
   const cspMode = process.env.CSP_MODE || "enforce"; // "off", "report-only", "enforce"
   if (cspMode !== "off") {
     const csp = [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline'",
-      "style-src 'self' 'unsafe-inline'",
+      `script-src 'self' 'nonce-${nonce}'`,
+      "style-src 'self' 'unsafe-inline'", // Svelte scoped styles require unsafe-inline
       "font-src 'self'",
       "img-src 'self' data: blob:",
       "connect-src 'self'",


### PR DESCRIPTION
## Summary

- **HSTS** — `Strict-Transport-Security` (max-age=31536000, includeSubDomains) in production: API via `@fastify/helmet`, web via `hooks.server.ts`
- **CSP nonce** — replace `unsafe-inline` with per-request nonce in `script-src`; nonce injected into SvelteKit hydration scripts via `transformPageChunk`
- **CORS wildcard guard** — `CORS_ORIGIN=*` now fails at startup via Zod `refine`
- **Rate limit** — remove module-level `isTest` var in `auth.ts`, inline `config.NODE_ENV` check

## Test plan
- [x] App starts and works in dev
- [x] CI passes (Trivy scan, build)
- [x] After merge: tag v1.0.0 and create release

🤖 Generated with [Claude Code](https://claude.com/claude-code)